### PR TITLE
Fix/geofence msg day of week

### DIFF
--- a/j2735_msgs/msg/DayOfWeek.msg
+++ b/j2735_msgs/msg/DayOfWeek.msg
@@ -22,11 +22,11 @@
 # 	sat (0)
 # }
 
-uint8 dow
+uint8[7] dow
 
 # enumeration values for day of week
 uint8 SUN = 6  
-uint8 MON = 5  
+uint8 MON = 5
 uint8 TUE = 4  
 uint8 WED = 3  
 uint8 THU = 2  

--- a/j2735_msgs/msg/TrafficControlGeometry.msg
+++ b/j2735_msgs/msg/TrafficControlGeometry.msg
@@ -47,12 +47,11 @@ int32 REFLAT_MAX = 900000000
 int32 REFLAT_MIN = -900000000
 
 # refelv Elevation ::= INTEGER (0..65535) -- offset by 4096, -4096 represents unknown, -409.5 to 6143.9 meters relative to referemce datum
-# above is the original spec, but CARMA generally follows the range below with -4096 (offset is handled in carma-messenger)
 int32 refelv
 
-int32 REFELV_UNKNOWN = -4096
-int32 REFELV_MAX = 61439
-int32 REFELV_MIN = -4095
+int32 REFELV_UNKNOWN = 0
+int32 REFELV_MAX = 65535
+int32 REFELV_MIN = 1
 
 # heading INTEGER (0..3599) -- initial path heading clockwise from north in tenths of degrees
 uint16 heading

--- a/j2735_msgs/msg/TrafficControlGeometry.msg
+++ b/j2735_msgs/msg/TrafficControlGeometry.msg
@@ -47,6 +47,7 @@ int32 REFLAT_MAX = 900000000
 int32 REFLAT_MIN = -900000000
 
 # refelv Elevation ::= INTEGER (0..65535) -- offset by 4096, -4096 represents unknown, -409.5 to 6143.9 meters relative to referemce datum
+# above is the original spec, but CARMA generally follows the range below with -4096 (offset is handled in carma-messenger)
 int32 refelv
 
 int32 REFELV_UNKNOWN = -4096


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
DayOfWeek.msg should have an array of dow elements rather than just one value as the spec if BIG STRING in asn1c. This error was discovered when updating the message node. Only carma-messenger is using this for geofence activities currently.

This also fixes the range of elevation in TrafficControlGeometry

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/778
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Buildable.
Tested by using it on message node.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.