### PR TITLE
Add initial velocity to trajectory plan

### DIFF
--- a/cav_msgs/msg/TrajectoryPlan.msg
+++ b/cav_msgs/msg/TrajectoryPlan.msg
@@ -9,5 +9,8 @@ std_msgs/Header header
 # The unique GUID of this trajectory
 string  trajectory_id
 
+# The vehicle's longitudinal velocity in m/s at the first point in the trajectory_points
+float64 initial_longitudinal_velocity
+
 # A list of trajectory plan points describe the detailed trajectory plan
 cav_msgs/TrajectoryPlanPoint[] trajectory_points


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds an initial velocity field to the trajectory plan message. Without this field it is not possible to properly convert times back to speeds as the speed at the first point is not known. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/pull/947
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See referenced PR
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.