### PR TITLE
Add vehicle state stamp

### DIFF
--- a/cav_srvs/srv/PlanTrajectory.srv
+++ b/cav_srvs/srv/PlanTrajectory.srv
@@ -6,6 +6,11 @@
 
 #request
 
+# Header
+# Stamp for the header should match time that vehicle state was computed. 
+# This may be later than the maneuver_plan header and possibly in the future if multiple plan trajectory requests were sent for one maneuver plan
+std_msgs/Header header 
+
 # The starting state of the vehicle
 cav_msgs/VehicleState vehicle_state
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds a header to PlanTrajectoy who's stamp matches the vehicle_state field such that the planned trajectory can be properly timed. 
<!--- Describe your changes in detail -->
Supports https://github.com/usdot-fhwa-stol/carma-platform/pull/1088
## Related Issue
See issue in refered PR
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1 run in blue lexus
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.