### PR TITLE
Hotfix/end of route park

### DIFF
--- a/cav_msgs/msg/GuidanceState.msg
+++ b/cav_msgs/msg/GuidanceState.msg
@@ -15,4 +15,5 @@ uint8 DRIVERS_READY = 2
 uint8 ACTIVE = 3
 uint8 ENGAGED = 4
 uint8 INACTIVE = 5
+uint8 ENTER_PARK = 6
 uint8 SHUTDOWN = 0


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds an 'ENTER_PARK' state to the GuidanceState message in accordance with the updated Guidance State Machine logic on branch hotfix/end_of_route_park in carma-platform.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 1069: Guidance state machine does not keep the vehicle stopped after completing a route](https://github.com/usdot-fhwa-stol/carma-platform/issues/1069)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prior to this change, when the vehicle came to a stop at the end of the route and a 'Route Completed' event occurred, there was no specific state machine behavior that checked whether the vehicle was shifted to Park before transitioning from the 'ENGAGED' state. An update to the guidance state machine logic has added a new 'ENTER_PARK' state, and the GuidanceState message had to be updated accordingly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested on the Blue Lexus.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.