### PR TITLE
Update PlanTrajectory.srv request to communicate maneuver index to be planned

### DIFF
--- a/cav_srvs/srv/PlanTrajectory.srv
+++ b/cav_srvs/srv/PlanTrajectory.srv
@@ -20,6 +20,9 @@ cav_msgs/ManeuverPlan maneuver_plan
 # The initial trajectory plan to be modified
 cav_msgs/TrajectoryPlan initial_trajectory_plan
 
+# The index specifying the maneuver within the maneuver plan that a trajectory must be planned for
+uint16 maneuver_index_to_plan
+
 ---
 
 #response


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds a field to the PlanTrajectory.srv request in order to communicate to a tactical plugin which maneuver plan index the request is for.

Related PR in carma-platform: [Refactor plan_delegator and tactical plugins for plan_trajectory_cb() maneuver sequencing](https://github.com/usdot-fhwa-stol/carma-platform/pull/1220)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 1106: Refactor plan_delegator and InLane-cruising to properly sequence maneuver/trajectory planning](https://github.com/usdot-fhwa-stol/carma-platform/issues/1106)
[Isseu 1036: Inlane cruising plugin cannot create trajectory plan for distributed maneuvers](https://github.com/usdot-fhwa-stol/carma-platform/issues/1036)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prior to this update, a tactical plugin in carma-platform would loop through a received maneuver plan and plan a trajectory for all relevant maneuvers in that plan. After this change, a tactical plugin will receive the intended maneuver index in the maneuver plan for which the trajectory planning service request is for.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested and integration tested on both the Ford Fusion and Black Pacifica.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.