### PR TITLE
Update SetActiveRoute.srv to include a 'choice' field and a destination points array field

### DIFF
--- a/cav_srvs/srv/SetActiveRoute.srv
+++ b/cav_srvs/srv/SetActiveRoute.srv
@@ -9,8 +9,19 @@
 #
 
 # Request
+
+# Enumeration values for the method being used to provide the route destination points
+uint8 choice
+
+uint8 ROUTE_ID=0
+uint8 DESTINATION_POINTS_ARRAY=1
+
 # The id of the route to select
 string routeID
+
+# The array of destination points to be used for route generation 
+cav_msgs/Position3D[] destination_points
+
 ---
 # Response
 # An enumeration representing a service execution error as defined in the route design document.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR adds a 'choice' enumeration field to the SetActiveRoute service request, which indicates whether a RouteID (the name of a route file) or an array of destination points (specifically, an array of cav_msgs/Position3D points) is being provided. Additionally, a field for an array of cav_msgs/Position3D points is included in order to store the destination points, where the last point is the final destination point. This update is being added in order to enable the Port Drayage Plugin package in carma-platform to set a new active route based on a received destination point from CARMA Streets.

Related PRs:

carma-platform: PR #[1321](https://github.com/usdot-fhwa-stol/carma-platform/pull/1321)
carma-web-ui: PR #[92](https://github.com/usdot-fhwa-stol/carma-web-ui/pull/92)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tested in carma-platform and integration tested (using both port drayage plugin package functionality and typical carma-web-ui route-setting functionality) on the Silver Lexus and Blue Lexus.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.