### PR TITLE
Update ROS Noetic branch to C++14

### DIFF
--- a/carma_debug_msgs/CMakeLists.txt
+++ b/carma_debug_msgs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(carma_debug_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/cav_msgs/CMakeLists.txt
+++ b/cav_msgs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cav_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/cav_srvs/CMakeLists.txt
+++ b/cav_srvs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cav_srvs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+# add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/j2735_msgs/CMakeLists.txt
+++ b/j2735_msgs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(j2735_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
# PR Details
## Description

Update the CMakeLists.txt files to specify c++14 instead of C++11. 

## Motivation and Context

Using C++ 14 to compile the CARMA source code on Ubuntu 20.04.

## How Has This Been Tested?

Full build and checking the output logs for C++ 14 usage.

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
