### PR TITLE
Fix typo in ManeuverParameters.msg

### DIFF
--- a/cav_msgs/msg/ManeuverParameters.msg
+++ b/cav_msgs/msg/ManeuverParameters.msg
@@ -9,7 +9,7 @@
 string  maneuver_id
 
 # Enum indicating the type of negotiation this maneuver is involved in
-uint8 neogition_type
+uint8 negotiation_type
 
 uint8 NO_NEGOTIATION = 0
 uint8 GENERAL_NEGOTIATION = 1


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
There is a typo in both carma-platform and carma-msgs where the ManeuverParameters.msg value "negotiation_type" is incorrectly spelled as "neogition_type" in multiple files
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/1371
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is to ensure that msg file values are correctly listed to avoid confusion.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.