### PR TITLE
Fix typo in `ManeuverParameters.msg` (`noetic/develop`)

### DIFF
--- a/cav_msgs/msg/ManeuverParameters.msg
+++ b/cav_msgs/msg/ManeuverParameters.msg
@@ -9,7 +9,7 @@
 string  maneuver_id
 
 # Enum indicating the type of negotiation this maneuver is involved in
-uint8 neogition_type
+uint8 negotiation_type
 
 uint8 NO_NEGOTIATION = 0
 uint8 GENERAL_NEGOTIATION = 1


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR fixes a typo in the `ManeuverParameters.msg` file. The `negotiation_type` field was incorrectly spelled as `neogition_type`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #122 for the `noetic/develop` branch.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There was a typo in a message field.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Field name ran through spell check.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.