### PR TITLE
Add vehicle state in plan_maneuvers service call request

### DIFF
--- a/cav_srvs/srv/PlanManeuvers.srv
+++ b/cav_srvs/srv/PlanManeuvers.srv
@@ -6,9 +6,38 @@
 
 #request
 
+# Header
+# Stamp for the header should match time that vehicle state was computed. 
+std_msgs/Header header 
+
 # Maneuvers planned prior to the current planning request.
 # These maneuvers must not be modified by this process
 cav_msgs/ManeuverPlan prior_plan
+
+### Vehicle Initial State
+# The following vehicle state values represent the state of the vehicle at the time specified by header 
+# These values should match the start conditions for the first maneuver in prior_plan
+# Therefore for planners called after prior_plan is populated these fields should be ignored
+# Instead the end conditions of the last maneuver in prior_plan should fill this role
+###
+
+# Vehicle initial 2d position in the frame specified by header at the time specified by header
+# Units: m
+float64 veh_x
+float64 veh_y
+
+# Vehicle initial position in the route frame. This must match the veh_x, veh_y values.
+# Units: m
+float64 veh_downtrack
+
+# Vehicle initial logitudinal velocity 
+# Units: m/s
+float64 veh_logitudinal_velocity
+
+# Vehicle initial lane id
+string veh_lane_id
+
+
 ---
 
 #response


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the plan_maneuvers service call request to include the initial vehicle state at the start of planning. This state should be used by Strategic Plugins when the prior_plan is empty. The reasoning for this change is that currently all the Strategic Plugins contain duplicated code to get the current position/lane/velocity information in order to begin maneuver planning. This means its possible for two strategic plugins to returns plans starting from slightly offset locations based on call order. This will make sequencing plans difficult. This change should help resolve that by providing a fixed source of truth as well as reducing code duplication. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1377
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See description
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.