### PR TITLE
Add the plugin activation message back into cav_srvs

### DIFF
--- a/cav_srvs/srv/PluginActivation.srv
+++ b/cav_srvs/srv/PluginActivation.srv
@@ -1,0 +1,23 @@
+#
+# Plugin Message
+# 
+# A command from the user to activate or deactivate a plugin
+#
+# @author Kyle Rush
+# @version 0.1
+#
+
+std_msgs/Header header
+
+# The name of the plugin to change the activation state for
+string plugin_name
+
+# The version of the plugin to change the activation state for
+string plugin_version
+
+# The state to change to
+bool activated
+
+---
+#Response
+bool newstate


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add the plugin activation message back into cav_srvs after is was accidently removed in the ROS2 conversion.

<!--- Describe your changes in detail -->

## Related Issue
Supports ROS2 milestone https://github.com/usdot-fhwa-stol/carma-platform/milestone/4
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Allow ROS1 plugins to still build
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Docker build testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.