### PR TITLE
Fix install folder permissions for ros1_bridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,5 @@ RUN source /opt/ros/noetic/setup.bash \
 && git clone --branch foxy https://github.com/ros2/ros1_bridge.git \
 && cd ../ \
 && sudo apt-get update \
-&& colcon build --packages-select ros1_bridge
+&& colcon build --packages-select ros1_bridge \
+&& sudo chmod -R ugo+x ~/.base-image/workspace/install


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the permissions of the installation folder used for the ros1_bridge so that is can be sourced properly from a carma-config docker-compose file. 

<!--- Describe your changes in detail -->

## Related Issue
Supports the ROS2 milestone https://github.com/usdot-fhwa-stol/carma-platform/milestone/4
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
ros1_bridge should be usable in a carma-config docker setup
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local testing using the development config
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.