### PR TITLE
Updated CAV message packages that can compile with same-lane join IHP strategic plugin.

### DIFF
--- a/cav_msgs/CMakeLists.txt
+++ b/cav_msgs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cav_msgs)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/cav_msgs/CMakeLists.txt
+++ b/cav_msgs/CMakeLists.txt
@@ -17,8 +17,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cav_msgs)
 
-## Compile as C++14, supported in ROS Noetic and newer
-add_compile_options(-std=c++14)
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/cav_msgs/msg/MobilityHeader.msg
+++ b/cav_msgs/msg/MobilityHeader.msg
@@ -12,9 +12,8 @@ string  sender_id
 # Empty string indicates a broadcast message
 string  recipient_id
 
-# sender's dynamic ID which is its BSM id in hex string
-# Example: "FFFFFFFF"
-string sender_bsm_id
+# BSM id has been removed.
+
 
 # random GUID that identifies this particular plan for future reference
 # Example: "b937d2f6-e618-4867-920b-c1f74f98ef1f"

--- a/cav_msgs/msg/MobilityHeader.msg
+++ b/cav_msgs/msg/MobilityHeader.msg
@@ -12,8 +12,10 @@ string  sender_id
 # Empty string indicates a broadcast message
 string  recipient_id
 
-# BSM id has been removed.
-
+# Note: BSM id has been removed from IHP2 platooning.
+# sender's dynamic ID which is its BSM id in hex string
+# Example: "FFFFFFFF"
+string sender_bsm_id
 
 # random GUID that identifies this particular plan for future reference
 # Example: "b937d2f6-e618-4867-920b-c1f74f98ef1f"

--- a/cav_msgs/msg/MobilityRequest.msg
+++ b/cav_msgs/msg/MobilityRequest.msg
@@ -31,3 +31,8 @@ cav_msgs/Trajectory            trajectory
 
 # time when this message is expired
 uint64                         expiration
+
+# the target index to join the platoon
+# -1 means join from front, otherwise indicate the gap leading vehicle's index
+uint16                         join_index
+

--- a/cav_msgs/msg/MobilityResponse.msg
+++ b/cav_msgs/msg/MobilityResponse.msg
@@ -11,3 +11,7 @@ uint16                   urgency
 
 # the content of this response
 bool                     is_accepted
+
+# type of the proposal being suggested to neighbors
+cav_msgs/PlanType        plan_type
+

--- a/cav_msgs/msg/PlanType.msg
+++ b/cav_msgs/msg/PlanType.msg
@@ -13,6 +13,21 @@ uint8       CHANGE_LANE_RIGHT = 2
 uint8       JOIN_PLATOON_AT_REAR = 3
 uint8       PLATOON_FOLLOWER_JOIN = 4
 
+# UCLA: ADDED FOR FRONTAL JOIN
+uint8       JOIN_PLATOON_FROM_FRONT= 5
+uint8       PLATOON_FRONT_JOIN = 6
+
+# UCLA: ADDED FOR CUT-IN JOIN
+uint8       CUT_IN_FROM_SIDE = 7
+uint8       PLATOON_CUTIN_JOIN = 8
+uint8       STOP_CREAT_GAP = 9
+uint8       CUT_IN_FRONT_DONE = 10
+uint8       CUT_IN_MID_OR_REAR_DONE = 11
+
+# UCLA: ADDED FOR DEPARTURE
+uint8 	    PLATOON_DEPARTURE = 12
+uint8       DELETE_MEMBER = 13
+
 # ideas for future additions:
 # uint8       SEARCHING_FOR_PLATOON = 5
 # uint8       DEPART_PLATOON = 6

--- a/cav_msgs/msg/PlatooningInfo.msg
+++ b/cav_msgs/msg/PlatooningInfo.msg
@@ -15,6 +15,7 @@ uint8    CONNECTING_TO_NEW_FOLLOWER=2
 uint8    CONNECTING_TO_NEW_LEADER=3
 uint8    LEADING=4
 uint8    FOLLOWING=5
+uint8	 DEPARTING=6
 
 # Current platoon ID (GUID)
 string   platoon_id


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Update cav_msgs package to match ihp platooning strategic plugin.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issue.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The changes are made to support the ihp2 platooning strategic plugin. The following messages are changed:

- Mobility Header
- Mobility Request
- Mobility Response
- Plan Type
- Platooning Info

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The updated CAV messages are compiled with ihp2 platooning strategic plugin.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.