### PR TITLE
Add HeadingStamped.msg back after accidental deletion during ros2 mig…

### DIFF
--- a/carma_driver_msgs/msg/HeadingStamped.msg
+++ b/carma_driver_msgs/msg/HeadingStamped.msg
@@ -1,0 +1,5 @@
+# HeadingStamped.msg
+# Orientation of the vehicle in global frame
+std_msgs/Header header
+
+float32 heading # Heading of the vehicle east of north

--- a/cav_msgs/msg/HeadingStamped.msg
+++ b/cav_msgs/msg/HeadingStamped.msg
@@ -1,0 +1,5 @@
+# HeadingStamped.msg
+# Orientation of the vehicle in global frame
+std_msgs/Header header
+
+float32 heading # Heading of the vehicle east of north


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds the HeadingStamped.msg file back into carma-msgs after is was accidently removed during the ROS2 message conversion. This message is used by the torc-pinpoint hardware driver and therefore carma-messenger.
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1609
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working carma-messenger in ros2
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test on the tahoe
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.