### PR TITLE
Match ros1 message fieldnames to ros2 message fieldnames

### DIFF
--- a/carma_v2x_msgs/msg/TrafficControlMessage.msg
+++ b/carma_v2x_msgs/msg/TrafficControlMessage.msg
@@ -14,7 +14,7 @@
 # TrafficControlMessage ::= CHOICE
 # {
 # 	reserved NULL, -- skip version zero
-# 	tcmV01 TrafficControlMessageV01, -- traffic control message version 1
+# 	tcm_v01 TrafficControlMessageV01, -- traffic control message version 1
 # 	...
 # }
 

--- a/carma_v2x_msgs/msg/TrafficControlMessage.msg
+++ b/carma_v2x_msgs/msg/TrafficControlMessage.msg
@@ -24,5 +24,5 @@ uint8 choice
 uint8 RESERVED=0
 uint8 TCMV01=1
 
-#tcrV01 ::= TrafficControlRequestV01
+#tcm_v01 ::= TrafficControlMessageV01
 carma_v2x_msgs/TrafficControlMessageV01 tcm_v01

--- a/carma_v2x_msgs/msg/TrafficControlRequest.msg
+++ b/carma_v2x_msgs/msg/TrafficControlRequest.msg
@@ -14,7 +14,7 @@
 #TrafficControlRequest ::= CHOICE
 #{
 #	reserved NULL, -- skip version zero
-#	tcrV01 TrafficControlRequestV01, -- traffic control request version 1
+#	tcr_v01 TrafficControlRequestV01, -- traffic control request version 1
 #	...
 #}
 

--- a/carma_v2x_msgs/msg/TrafficControlRequest.msg
+++ b/carma_v2x_msgs/msg/TrafficControlRequest.msg
@@ -23,5 +23,5 @@ uint8 choice
 uint8 RESERVED=0
 uint8 TCRV01=1
 
-#tcrV01 ::= TrafficControlRequestV01
+#tcr_v01 ::= TrafficControlRequestV01
 carma_v2x_msgs/TrafficControlRequestV01 tcr_v01

--- a/cav_msgs/msg/ByteArray.msg
+++ b/cav_msgs/msg/ByteArray.msg
@@ -14,7 +14,7 @@
 std_msgs/Header header
 
 # Need to know the type before parsing. MessageTypes are MAP, SPAT, TIM, BSM, Mobility.
-string messageType
+string message_type
 
 # The DSRC message content
 uint8[] content

--- a/cav_msgs/msg/TrafficControlMessage.msg
+++ b/cav_msgs/msg/TrafficControlMessage.msg
@@ -14,7 +14,7 @@
 # TrafficControlMessage ::= CHOICE
 # {
 # 	reserved NULL, -- skip version zero
-# 	tcmV01 TrafficControlMessageV01, -- traffic control message version 1
+# 	tcm_v01 TrafficControlMessageV01, -- traffic control message version 1
 # 	...
 # }
 

--- a/cav_msgs/msg/TrafficControlMessage.msg
+++ b/cav_msgs/msg/TrafficControlMessage.msg
@@ -24,5 +24,5 @@ uint8 choice
 uint8 RESERVED=0
 uint8 TCMV01=1
 
-#tcrV01 ::= TrafficControlRequestV01
+#tcm_v01 ::= TrafficControlMessageV01
 cav_msgs/TrafficControlMessageV01 tcm_v01

--- a/cav_msgs/msg/TrafficControlMessage.msg
+++ b/cav_msgs/msg/TrafficControlMessage.msg
@@ -25,4 +25,4 @@ uint8 RESERVED=0
 uint8 TCMV01=1
 
 #tcrV01 ::= TrafficControlRequestV01
-cav_msgs/TrafficControlMessageV01 tcmV01
+cav_msgs/TrafficControlMessageV01 tcm_v01

--- a/cav_msgs/msg/TrafficControlRequest.msg
+++ b/cav_msgs/msg/TrafficControlRequest.msg
@@ -24,4 +24,4 @@ uint8 RESERVED=0
 uint8 TCRV01=1
 
 #tcrV01 ::= TrafficControlRequestV01
-cav_msgs/TrafficControlRequestV01 tcrV01
+cav_msgs/TrafficControlRequestV01 tcr_v01

--- a/cav_msgs/msg/TrafficControlRequest.msg
+++ b/cav_msgs/msg/TrafficControlRequest.msg
@@ -14,7 +14,7 @@
 #TrafficControlRequest ::= CHOICE
 #{
 #	reserved NULL, -- skip version zero
-#	tcrV01 TrafficControlRequestV01, -- traffic control request version 1
+#	tcr_v01 TrafficControlRequestV01, -- traffic control request version 1
 #	...
 #}
 

--- a/cav_msgs/msg/TrafficControlRequest.msg
+++ b/cav_msgs/msg/TrafficControlRequest.msg
@@ -23,5 +23,5 @@ uint8 choice
 uint8 RESERVED=0
 uint8 TCRV01=1
 
-#tcrV01 ::= TrafficControlRequestV01
+#tcr_v01 ::= TrafficControlRequestV01
 cav_msgs/TrafficControlRequestV01 tcr_v01


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR updates ROS1 fieldnames to match their corresponding ROS2 fieldnames for the following ROS1 messages: TrafficControlRequest, TrafficControlMessage, ByteArray. Prior to this change, the ros1_bridge was unable to create a 2to1 bridge for the topics involving these messages.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Ford Fusion

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.