### PR TITLE
Feature/add psm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.vcs-ref=${VCS_REF}
 LABEL org.label-schema.build-date=${BUILD_DATE}
 
 # Clone autoware repo to access messages
-RUN cd /home/carma/ && git clone https://github.com/usdot-fhwa-stol/autoware.ai.git --depth 1 --branch develop
+RUN cd /home/carma/ && git clone https://github.com/usdot-fhwa-stol/autoware.ai.git --depth 1 --branch carma-develop
 
 # ROS 1 msgs setup
 RUN mkdir -p ~/.base-image/ros1_msgs_ws/src/carma_msgs

--- a/carma_v2x_msgs/msg/AttachmentRadius.msg
+++ b/carma_v2x_msgs/msg/AttachmentRadius.msg
@@ -9,5 +9,5 @@
 # AttachmentRadius in meters in range (0..20)
 float32 attachment_radius
 
-float32 ATTACHMENT_RADIUS_MIN= 0
-float32 ATTACHMENT_RADIUS_MAX = 20
+float32 ATTACHMENT_RADIUS_MIN= 0.0
+float32 ATTACHMENT_RADIUS_MAX = 20.0

--- a/carma_v2x_msgs/msg/AttachmentRadius.msg
+++ b/carma_v2x_msgs/msg/AttachmentRadius.msg
@@ -1,0 +1,13 @@
+#
+# AttachmentRadius.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of AttachmentRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# AttachmentRadius in meters in range (0..20)
+float32 attachment_radius
+
+float32 ATTACHMENT_RADIUS_MIN= 0
+float32 ATTACHMENT_RADIUS_MAX = 20

--- a/carma_v2x_msgs/msg/Elevation.msg
+++ b/carma_v2x_msgs/msg/Elevation.msg
@@ -1,0 +1,17 @@
+#
+# Elevation.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Elevation from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# Elevation in meters in range (-409.6..6143.9)
+float32 elevation
+
+float32 MIN=-409.6
+float32 MAX=6143.9
+
+# If true then elevation is unavailable
+bool unavailable

--- a/carma_v2x_msgs/msg/FullPositionVector.msg
+++ b/carma_v2x_msgs/msg/FullPositionVector.msg
@@ -1,0 +1,44 @@
+#
+# FullPositionVector.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of FullPositionVector from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_HEADING) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_HEADING
+uint16 presence_vector
+
+uint16 HAS_UTC_TIME=1
+uint16 HAS_ELEVATION=2
+uint16 HAS_HEADING=4
+uint16 HAS_SPEED=8
+uint16 HAS_POS_ACCURACY=16
+uint16 HAS_TIME_CONFIDENCE=32
+uint16 HAS_POS_CONFIDENCE=64
+uint16 HAS_SPEED_CONFIDENCE=128
+
+j2735_v2x_msgs/DDateTime utc_time
+
+carma_v2x_msgs/Longitude lon
+
+carma_v2x_msgs/Latitude lat
+
+carma_v2x_msgs/Elevation elevation
+
+carma_v2x_msgs/Heading heading
+
+carma_v2x_msgs/TransmissionAndSpeed speed
+
+carma_v2x_msgs/PositionalAccuracy pos_accuracy
+
+j2735_v2x_msgs/TimeConfidence time_confidence
+
+j2735_v2x_msgs/PositionConfidenceSet pos_confidence
+
+j2735_v2x_msgs/SpeedandHeadingandThrottleConfidence speed_confidence

--- a/carma_v2x_msgs/msg/Heading.msg
+++ b/carma_v2x_msgs/msg/Heading.msg
@@ -9,7 +9,7 @@
 # Heading in degrees in range (0..359.9875)
 float32 heading
 
-float32 MIN=0
+float32 MIN=0.0
 float32 MAX=359.9875
 
 # If true then heading is unavailable

--- a/carma_v2x_msgs/msg/Heading.msg
+++ b/carma_v2x_msgs/msg/Heading.msg
@@ -1,0 +1,16 @@
+#
+# Heading.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Heading from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Heading in degrees in range (0..359.9875)
+float32 heading
+
+float32 MIN=0
+float32 MAX=359.9875
+
+# If true then heading is unavailable
+bool unavailable

--- a/carma_v2x_msgs/msg/Latitude.msg
+++ b/carma_v2x_msgs/msg/Latitude.msg
@@ -9,8 +9,8 @@
 # Latitude in degrees in range (-90..90)
 float64 latitude
 
-float32 MIN=-90
-float32 MAX=90
+float32 MIN=-90.0
+float32 MAX=90.0
 
 # True if the latitude value is unavailable
 bool unavailable

--- a/carma_v2x_msgs/msg/Latitude.msg
+++ b/carma_v2x_msgs/msg/Latitude.msg
@@ -1,0 +1,16 @@
+#
+# Latitude.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Latitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Latitude in degrees in range (-90..90)
+float64 latitude
+
+float32 MIN=-90
+float32 MAX=90
+
+# True if the latitude value is unavailable
+bool unavailable

--- a/carma_v2x_msgs/msg/Longitude.msg
+++ b/carma_v2x_msgs/msg/Longitude.msg
@@ -1,0 +1,16 @@
+#
+# Longitude.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Longitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Longitude in degrees in range (-179.9999999..180.000000)
+float64 longitude
+
+float32 MIN=-179.9999999
+float32 MAX=180.000000
+
+# True if longitude is unavailable
+bool unavailable

--- a/carma_v2x_msgs/msg/PSM.msg
+++ b/carma_v2x_msgs/msg/PSM.msg
@@ -1,0 +1,95 @@
+#
+# PSM.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PSM from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional feilds.
+# Compare with bitwise-and
+# if (presence_vector & HAS_PATH_HISTORY) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_PATH_HISTORY
+uint32 presence_vector
+
+uint32 HAS_ACCEL_SET = 1
+uint32 HAS_PATH_HISTORY = 2
+uint32 HAS_PATH_PREDICTION = 4
+uint32 HAS_PROPULSION = 8
+uint32 HAS_USE_STATE = 16
+uint32 HAS_CROSS_REQUEST = 32
+uint32 HAS_CROSS_STATE = 64
+uint32 HAS_CLUSTER_SIZE = 128
+uint32 HAS_CLUSTER_RADIUS = 256
+uint32 HAS_EVENT_RESPONDER_TYPE = 512
+uint32 HAS_ACTIVITY_TYPE = 1024
+uint32 HAS_ACTIVITY_SUB_TYPE = 2048
+uint32 HAS_ASSIST_TYPE = 4096
+uint32 HAS_SIZING = 8192
+uint32 HAS_ATTACHMENT= 16384
+uint32 HAS_ATTACHMENT_RADIUS = 32768
+uint32 HAS_ANIMAL_TYPE = 65536
+uint32 HAS_REGIONAL_EXTENSION = 131072
+
+j2735_v2x_msgs/PersonalDeviceUserType basic_type
+
+j2735_v2x_msgs/DSecond sec_mark
+
+j2735_v2x_msgs/MsgCount msg_cnt
+
+j2735_v2x_msgs/TemporaryID id
+
+carma_v2x_msgs/Position3D position
+
+carma_v2x_msgs/PositionalAccuracy accuracy
+
+carma_v2x_msgs/Velocity speed
+
+carma_v2x_msgs/Heading heading
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+carma_v2x_msgs/AccelerationSet4Way accel_set
+
+carma_v2x_msgs/PathHistory path_history
+
+carma_v2x_msgs/PathPrediction path_prediction
+
+j2735_v2x_msgs/PropelledInformation propulsion
+
+j2735_v2x_msgs/PersonalDeviceUsageState use_state
+
+j2735_v2x_msgs/PersonalCrossingRequest cross_request
+
+j2735_v2x_msgs/PersonalCrossingInProgress cross_state
+
+j2735_v2x_msgs/NumberOfParticipantsInCluster cluster_size
+
+j2735_v2x_msgs/PersonalClusterRadius cluster_radius
+
+j2735_v2x_msgs/PublicSafetyEventResponderWorkerType event_responder_type
+
+j2735_v2x_msgs/PublicSafetyAndRoadWorkerActivity activity_type
+
+j2735_v2x_msgs/PublicSafetyDirectingTrafficSubType activity_sub_type
+
+j2735_v2x_msgs/PersonalAssistive assist_type
+
+j2735_v2x_msgs/UserSizeAndBehaviour sizing
+
+j2735_v2x_msgs/Attachment attachment
+
+carma_v2x_msgs/AttachmentRadius attachment_radius
+
+j2735_v2x_msgs/AnimalType animal_type
+
+# TODO Approach to defining regional extensions in ROS has not yet been idenfied. If it is, this field will be updated.
+# regional SEQUENCE (SIZE(1..4)) OF 
+#            j2735_v2x_msgs/RegionalExtension {{REGION.Reg-PersonalSafetyMessage}} OPTIONAL,
+#   ...
+#   }

--- a/carma_v2x_msgs/msg/PathHistory.msg
+++ b/carma_v2x_msgs/msg/PathHistory.msg
@@ -1,0 +1,27 @@
+#
+# PathHistory.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PathHistory from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_CURR_GNSS_STATUS) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_CURR_GNSS_STATUS
+uint8 presence_vector
+
+uint8 HAS_CURR_GNSS_STATUS = 1
+uint8 HAS_INITIAL_POSITION = 2
+
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+carma_v2x_msgs/FullPositionVector initial_position
+j2735_v2x_msgs/GNSSStatus curr_gnss_status

--- a/carma_v2x_msgs/msg/PathPrediction.msg
+++ b/carma_v2x_msgs/msg/PathPrediction.msg
@@ -1,0 +1,21 @@
+#
+# PathPrediction.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PathPrediction from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# RadiusOfCurvature in meters in range (-327.67..327.67)
+float32 radius_of_curvature
+
+float32 MIN_RADIUS=-327.67
+float32 MAX_RADIUS=327.67
+
+
+# Confidence percentage in range (0..200)
+float32 confidence
+
+float32 MIN_CONFIDENCE=0
+float32 MAX_CONFIDENCE=200

--- a/carma_v2x_msgs/msg/PathPrediction.msg
+++ b/carma_v2x_msgs/msg/PathPrediction.msg
@@ -17,5 +17,5 @@ float32 MAX_RADIUS=327.67
 # Confidence percentage in range (0..200)
 float32 confidence
 
-float32 MIN_CONFIDENCE=0
-float32 MAX_CONFIDENCE=200
+float32 MIN_CONFIDENCE=0.0
+float32 MAX_CONFIDENCE=200.0

--- a/carma_v2x_msgs/msg/TransmissionAndSpeed.msg
+++ b/carma_v2x_msgs/msg/TransmissionAndSpeed.msg
@@ -1,0 +1,12 @@
+#
+# TransmissionAndSpeed.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of TransmissionAndSpeed from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+j2735_v2x_msgs/TransmissionState transmission
+
+carma_v2x_msgs/Velocity speed

--- a/carma_v2x_msgs/msg/Velocity.msg
+++ b/carma_v2x_msgs/msg/Velocity.msg
@@ -10,7 +10,7 @@
 # Velocity in m/s in range (0..163.82)
 float32 velocity
 
-float32 MIN=0
+float32 MIN=0.0
 float32 MAX=163.82
 
 # If true the velocity is unavailable

--- a/carma_v2x_msgs/msg/Velocity.msg
+++ b/carma_v2x_msgs/msg/Velocity.msg
@@ -1,0 +1,17 @@
+#
+# Velocity.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Velocity from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# Velocity in m/s in range (0..163.82)
+float32 velocity
+
+float32 MIN=0
+float32 MAX=163.82
+
+# If true the velocity is unavailable
+bool unavailable

--- a/cav_msgs/msg/AttachmentRadius.msg
+++ b/cav_msgs/msg/AttachmentRadius.msg
@@ -9,5 +9,5 @@
 # AttachmentRadius in meters in range (0..20)
 float32 attachment_radius
 
-float32 ATTACHMENT_RADIUS_MIN= 0
-float32 ATTACHMENT_RADIUS_MAX = 20
+float32 ATTACHMENT_RADIUS_MIN= 0.0
+float32 ATTACHMENT_RADIUS_MAX = 20.0

--- a/cav_msgs/msg/AttachmentRadius.msg
+++ b/cav_msgs/msg/AttachmentRadius.msg
@@ -1,0 +1,13 @@
+#
+# AttachmentRadius.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of AttachmentRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# AttachmentRadius in meters in range (0..20)
+float32 attachment_radius
+
+float32 ATTACHMENT_RADIUS_MIN= 0
+float32 ATTACHMENT_RADIUS_MAX = 20

--- a/cav_msgs/msg/Elevation.msg
+++ b/cav_msgs/msg/Elevation.msg
@@ -1,0 +1,17 @@
+#
+# Elevation.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Elevation from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# Elevation in meters in range (-409.6..6143.9)
+float32 elevation
+
+float32 MIN=-409.6
+float32 MAX=6143.9
+
+# If true then elevation is unavailable
+bool unavailable

--- a/cav_msgs/msg/FullPositionVector.msg
+++ b/cav_msgs/msg/FullPositionVector.msg
@@ -1,0 +1,44 @@
+#
+# FullPositionVector.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of FullPositionVector from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_HEADING) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_HEADING
+uint16 presence_vector
+
+uint16 HAS_UTC_TIME=1
+uint16 HAS_ELEVATION=2
+uint16 HAS_HEADING=4
+uint16 HAS_SPEED=8
+uint16 HAS_POS_ACCURACY=16
+uint16 HAS_TIME_CONFIDENCE=32
+uint16 HAS_POS_CONFIDENCE=64
+uint16 HAS_SPEED_CONFIDENCE=128
+
+j2735_msgs/DDateTime utc_time
+
+cav_msgs/Longitude lon
+
+cav_msgs/Latitude lat
+
+cav_msgs/Elevation elevation
+
+cav_msgs/Heading heading
+
+cav_msgs/TransmissionAndSpeed speed
+
+cav_msgs/PositionalAccuracy pos_accuracy
+
+j2735_msgs/TimeConfidence time_confidence
+
+j2735_msgs/PositionConfidenceSet pos_confidence
+
+j2735_msgs/SpeedandHeadingandThrottleConfidence speed_confidence

--- a/cav_msgs/msg/Heading.msg
+++ b/cav_msgs/msg/Heading.msg
@@ -9,7 +9,7 @@
 # Heading in degrees in range (0..359.9875)
 float32 heading
 
-float32 MIN=0
+float32 MIN=0.0
 float32 MAX=359.9875
 
 # If true then heading is unavailable

--- a/cav_msgs/msg/Heading.msg
+++ b/cav_msgs/msg/Heading.msg
@@ -1,0 +1,16 @@
+#
+# Heading.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Heading from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Heading in degrees in range (0..359.9875)
+float32 heading
+
+float32 MIN=0
+float32 MAX=359.9875
+
+# If true then heading is unavailable
+bool unavailable

--- a/cav_msgs/msg/Latitude.msg
+++ b/cav_msgs/msg/Latitude.msg
@@ -9,8 +9,8 @@
 # Latitude in degrees in range (-90..90)
 float64 latitude
 
-float32 MIN=-90
-float32 MAX=90
+float32 MIN=-90.0
+float32 MAX=90.0
 
 # True if the latitude value is unavailable
 bool unavailable

--- a/cav_msgs/msg/Latitude.msg
+++ b/cav_msgs/msg/Latitude.msg
@@ -1,0 +1,16 @@
+#
+# Latitude.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Latitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Latitude in degrees in range (-90..90)
+float64 latitude
+
+float32 MIN=-90
+float32 MAX=90
+
+# True if the latitude value is unavailable
+bool unavailable

--- a/cav_msgs/msg/Longitude.msg
+++ b/cav_msgs/msg/Longitude.msg
@@ -1,0 +1,16 @@
+#
+# Longitude.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Longitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+# Longitude in degrees in range (-179.9999999..180.000000)
+float64 longitude
+
+float32 MIN=-179.9999999
+float32 MAX=180.000000
+
+# True if longitude is unavailable
+bool unavailable

--- a/cav_msgs/msg/PSM.msg
+++ b/cav_msgs/msg/PSM.msg
@@ -1,0 +1,95 @@
+#
+# PSM.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PSM from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional feilds.
+# Compare with bitwise-and
+# if (presence_vector & HAS_PATH_HISTORY) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_PATH_HISTORY
+uint32 presence_vector
+
+uint32 HAS_ACCEL_SET = 1
+uint32 HAS_PATH_HISTORY = 2
+uint32 HAS_PATH_PREDICTION = 4
+uint32 HAS_PROPULSION = 8
+uint32 HAS_USE_STATE = 16
+uint32 HAS_CROSS_REQUEST = 32
+uint32 HAS_CROSS_STATE = 64
+uint32 HAS_CLUSTER_SIZE = 128
+uint32 HAS_CLUSTER_RADIUS = 256
+uint32 HAS_EVENT_RESPONDER_TYPE = 512
+uint32 HAS_ACTIVITY_TYPE = 1024
+uint32 HAS_ACTIVITY_SUB_TYPE = 2048
+uint32 HAS_ASSIST_TYPE = 4096
+uint32 HAS_SIZING = 8192
+uint32 HAS_ATTACHMENT= 16384
+uint32 HAS_ATTACHMENT_RADIUS = 32768
+uint32 HAS_ANIMAL_TYPE = 65536
+uint32 HAS_REGIONAL_EXTENSION = 131072
+
+j2735_msgs/PersonalDeviceUserType basic_type
+
+j2735_msgs/DSecond sec_mark
+
+j2735_msgs/MsgCount msg_cnt
+
+j2735_msgs/TemporaryID id
+
+cav_msgs/Position3D position
+
+cav_msgs/PositionalAccuracy accuracy
+
+cav_msgs/Velocity speed
+
+cav_msgs/Heading heading
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+cav_msgs/AccelerationSet4Way accel_set
+
+cav_msgs/PathHistory path_history
+
+cav_msgs/PathPrediction path_prediction
+
+j2735_msgs/PropelledInformation propulsion
+
+j2735_msgs/PersonalDeviceUsageState use_state
+
+j2735_msgs/PersonalCrossingRequest cross_request
+
+j2735_msgs/PersonalCrossingInProgress cross_state
+
+j2735_msgs/NumberOfParticipantsInCluster cluster_size
+
+j2735_msgs/PersonalClusterRadius cluster_radius
+
+j2735_msgs/PublicSafetyEventResponderWorkerType event_responder_type
+
+j2735_msgs/PublicSafetyAndRoadWorkerActivity activity_type
+
+j2735_msgs/PublicSafetyDirectingTrafficSubType activity_sub_type
+
+j2735_msgs/PersonalAssistive assist_type
+
+j2735_msgs/UserSizeAndBehaviour sizing
+
+j2735_msgs/Attachment attachment
+
+cav_msgs/AttachmentRadius attachment_radius
+
+j2735_msgs/AnimalType animal_type
+
+# TODO Approach to defining regional extensions in ROS has not yet been idenfied. If it is, this field will be updated.
+# regional SEQUENCE (SIZE(1..4)) OF 
+#            j2735_msgs/RegionalExtension {{REGION.Reg-PersonalSafetyMessage}} OPTIONAL,
+#   ...
+#   }

--- a/cav_msgs/msg/PathHistory.msg
+++ b/cav_msgs/msg/PathHistory.msg
@@ -1,0 +1,27 @@
+#
+# PathHistory.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PathHistory from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_CURR_GNSS_STATUS) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_CURR_GNSS_STATUS
+uint8 presence_vector
+
+uint8 HAS_CURR_GNSS_STATUS = 1
+uint8 HAS_INITIAL_POSITION = 2
+
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+cav_msgs/FullPositionVector initial_position
+j2735_msgs/GNSSStatus curr_gnss_status

--- a/cav_msgs/msg/PathPrediction.msg
+++ b/cav_msgs/msg/PathPrediction.msg
@@ -1,0 +1,21 @@
+#
+# PathPrediction.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of PathPrediction from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# RadiusOfCurvature in meters in range (-327.67..327.67)
+float32 radius_of_curvature
+
+float32 MIN_RADIUS=-327.67
+float32 MAX_RADIUS=327.67
+
+
+# Confidence percentage in range (0..200)
+float32 confidence
+
+float32 MIN_CONFIDENCE=0
+float32 MAX_CONFIDENCE=200

--- a/cav_msgs/msg/PathPrediction.msg
+++ b/cav_msgs/msg/PathPrediction.msg
@@ -17,5 +17,5 @@ float32 MAX_RADIUS=327.67
 # Confidence percentage in range (0..200)
 float32 confidence
 
-float32 MIN_CONFIDENCE=0
-float32 MAX_CONFIDENCE=200
+float32 MIN_CONFIDENCE=0.0
+float32 MAX_CONFIDENCE=200.0

--- a/cav_msgs/msg/TransmissionAndSpeed.msg
+++ b/cav_msgs/msg/TransmissionAndSpeed.msg
@@ -1,0 +1,12 @@
+#
+# TransmissionAndSpeed.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of TransmissionAndSpeed from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+j2735_msgs/TransmissionState transmission
+
+cav_msgs/Velocity speed

--- a/cav_msgs/msg/Velocity.msg
+++ b/cav_msgs/msg/Velocity.msg
@@ -10,7 +10,7 @@
 # Velocity in m/s in range (0..163.82)
 float32 velocity
 
-float32 MIN=0
+float32 MIN=0.0
 float32 MAX=163.82
 
 # If true the velocity is unavailable

--- a/cav_msgs/msg/Velocity.msg
+++ b/cav_msgs/msg/Velocity.msg
@@ -1,0 +1,17 @@
+#
+# Velocity.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+# Parsed description of Velocity from the SAE J2735 2016 specification.
+# For further usage details consult the specification. See note on SI units above.
+#
+
+# Velocity in m/s in range (0..163.82)
+float32 velocity
+
+float32 MIN=0
+float32 MAX=163.82
+
+# If true the velocity is unavailable
+bool unavailable

--- a/j2735_msgs/msg/AnimalPropelledType.msg
+++ b/j2735_msgs/msg/AnimalPropelledType.msg
@@ -1,0 +1,22 @@
+#
+# AnimalPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AnimalPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AnimalPropelledType ::= ENUMERATED {   
+#    unavailable         (0),
+#    otherTypes          (1), -- any method not listed below
+#    animalMounted       (2), -- as in horseback          
+#    animalDrawnCarriage (3),
+#    ...
+# }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 ANIMAL_MOUNTED=2
+uint8 ANIMAL_DRAWN_CARRIAGE=3

--- a/j2735_msgs/msg/AnimalType.msg
+++ b/j2735_msgs/msg/AnimalType.msg
@@ -1,0 +1,22 @@
+#
+# AnimalType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AnimalType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AnimalType ::= ENUMERATED { 
+#    unavailable    (0), 
+#    serviceUse     (1),  -- Includes guide or police animals
+#    pet            (2),
+#    farm           (3),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 SERVICE_USE=1
+uint8 PET=2
+uint8 FARM=3

--- a/j2735_msgs/msg/Attachment.msg
+++ b/j2735_msgs/msg/Attachment.msg
@@ -1,0 +1,28 @@
+#
+# Attachment.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Attachment from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Attachment ::= ENUMERATED { 
+#    unavailable                  (0), -- has some unknown attachment type
+#    stroller                     (1),
+#    bicycleTrailer               (2),
+#    cart                         (3),
+#    wheelchair                   (4), 
+#    otherWalkAssistAttachments   (5),
+#    pet                          (6),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE = 0
+uint8 STROLLER = 1
+uint8 BICYCLE_TRAILER = 2
+uint8 CART = 3
+uint8 WHEELCHAIR = 4
+uint8 OTHER_WALK_ASSIST_ATTACHMENTS = 5
+uint8 PET = 6

--- a/j2735_msgs/msg/AttachmentRadius.msg
+++ b/j2735_msgs/msg/AttachmentRadius.msg
@@ -1,0 +1,12 @@
+#
+# AttachmentRadius.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AttachmentRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AttachmentRadius ::= INTEGER (0..200) -- In LSB units of one decimeter
+uint8 attachment_radius
+
+uint8 ATTACHMENT_RADIUS_MAX = 200

--- a/j2735_msgs/msg/DDateTime.msg
+++ b/j2735_msgs/msg/DDateTime.msg
@@ -1,0 +1,49 @@
+#
+# DDateTime.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DDateTime from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# DDateTime ::= SEQUENCE {
+#    year    DYear    OPTIONAL,    
+#    month   DMonth   OPTIONAL,   
+#    day     DDay     OPTIONAL,  
+#    hour    DHour    OPTIONAL,   
+#    minute  DMinute  OPTIONAL,  
+#    second  DSecond  OPTIONAL,  
+#    offset  DOffset  OPTIONAL -- time zone
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & YEAR) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | YEAR
+uint8 presence_vector
+
+uint8 UNSET = 0
+uint8 YEAR=1
+uint8 MONTH=2
+uint8 DAY=4
+uint8 HOUR=8
+uint8 MINUTE=16
+uint8 SECOND=32
+uint8 OFFSET=64
+
+j2735_msgs/DYear year
+
+j2735_msgs/DMonth month
+
+j2735_msgs/DDay day
+
+j2735_msgs/DHour hour
+
+j2735_msgs/DMinute minute
+
+j2735_msgs/DSecond second
+
+j2735_msgs/DOffset offset
+

--- a/j2735_msgs/msg/DDay.msg
+++ b/j2735_msgs/msg/DDay.msg
@@ -1,0 +1,13 @@
+#
+# DDay.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DDay from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DDay ::= INTEGER (0..31)  -- units of days
+uint8 day
+
+uint8 UNAVAILABLE=0
+uint8 MAX=31

--- a/j2735_msgs/msg/DHour.msg
+++ b/j2735_msgs/msg/DHour.msg
@@ -1,0 +1,17 @@
+#
+# DHour.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DHour from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DHour ::= INTEGER (0..31) -- units of hours
+# Hour of day is 0-23, 31 denotes unvailable and 24-30 are reserved for transit schedule adherence
+uint8 hour
+
+uint8 HOUR_OF_DAY_MIN=0
+uint8 HOUR_OF_DAY_MAX=31
+uint8 TRANSITE_SCHEDULE_ADHERENCE_START=24
+uint8 TRANSITE_SCHEDULE_ADHERENCE_END=30
+uint8 UNAVAILABLE=31

--- a/j2735_msgs/msg/DMinute.msg
+++ b/j2735_msgs/msg/DMinute.msg
@@ -1,0 +1,15 @@
+#
+# DMinute.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DMinute from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DMinute ::= INTEGER (0..60) -- units of minutes
+
+uint8 minute
+
+uint8 MINUTE_IN_HOUR_MIN=0
+uint8 MINUTE_IN_HOUR_MAX=59
+uint8 UNAVAILABLE=60

--- a/j2735_msgs/msg/DMonth.msg
+++ b/j2735_msgs/msg/DMonth.msg
@@ -1,0 +1,13 @@
+#
+# DMonth.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DMonth from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DMonth ::= INTEGER (0..12) -- units of months
+uint8 month
+
+uint8 UNAVAILABLE=0
+uint8 MAX=12

--- a/j2735_msgs/msg/DOffset.msg
+++ b/j2735_msgs/msg/DOffset.msg
@@ -1,0 +1,15 @@
+#
+# DOffset.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DOffset from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DOffset ::= INTEGER (-840..840) -- units of minutes from UTC time
+
+int16 offset_minute
+
+int16 MIN=-840
+int16 MAX=840
+int16 UNAVAILABLE=0

--- a/j2735_msgs/msg/DSecond.msg
+++ b/j2735_msgs/msg/DSecond.msg
@@ -1,0 +1,19 @@
+#
+# DSecond.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DSecond from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DSecond ::= INTEGER (0..65535) -- units of milliseconds
+
+uint16 millisecond
+
+uint16 MILLISEC_WITHIN_MINUTE_NON_LEAP_MIN=0
+uint16 MILLISEC_WITHIN_MINUTE_NON_LEAP_MAX=59999
+uint16 MILLISEC_WITHIN_MINUTE_LEAP_MIN=60000
+uint16 MILLISEC_WITHIN_MINUTE_LEAP_MAX=60999
+uint16 RESERVED_MIN=61000
+uint16 RESERVED_MAX=65534
+uint16 UNAVAILABLE=65535

--- a/j2735_msgs/msg/DYear.msg
+++ b/j2735_msgs/msg/DYear.msg
@@ -1,0 +1,13 @@
+#
+# DYear.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DYear from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DYear ::= INTEGER (0..4095) -- units of years
+uint16 year
+
+uint16 UNAVAILABLE=0
+uint16 MAX=4095

--- a/j2735_msgs/msg/Elevation.msg
+++ b/j2735_msgs/msg/Elevation.msg
@@ -1,0 +1,19 @@
+#
+# Elevation.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Elevation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# elevation Elevation, -- in 10 cm units
+# Elevation ::= INTEGER (-4096..61439)
+#  -- In units of 10 cm steps above or below the reference ellipsoid
+#  -- Providing a range of -409.5 to + 6143.9 meters
+#  -- The value -4096 shall be used when Unknown is to be sent
+#  -- Convert to meter with factor 0.1 when field is used
+int32 elevation
+
+int32 ELEVATION_UNAVAILABLE = -4096
+int32 ELEVATION_MAX = 61439
+int32 ELEVATION_MIN = -4095

--- a/j2735_msgs/msg/ElevationConfidence.msg
+++ b/j2735_msgs/msg/ElevationConfidence.msg
@@ -1,0 +1,45 @@
+#
+# ElevationConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of ElevationConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# ElevationConfidence ::= ENUMERATED {
+#    unavailable (0),  -- B'0000  Not Equipped or unavailable
+#    elev-500-00 (1),  -- B'0001  (500 m)
+#    elev-200-00 (2),  -- B'0010  (200 m)
+#    elev-100-00 (3),  -- B'0011  (100 m)
+#    elev-050-00 (4),  -- B'0100  (50 m)
+#    elev-020-00 (5),  -- B'0101  (20 m)
+#    elev-010-00 (6),  -- B'0110  (10 m)
+#    elev-005-00 (7),  -- B'0111  (5 m)
+#    elev-002-00 (8),  -- B'1000  (2 m)
+#    elev-001-00 (9),  -- B'1001  (1 m)
+#    elev-000-50 (10), -- B'1010  (50 cm)
+#    elev-000-20 (11), -- B'1011  (20 cm)
+#    elev-000-10 (12), -- B'1100  (10 cm)
+#    elev-000-05 (13), -- B'1101  (5 cm)
+#    elev-000-02 (14), -- B'1110  (2 cm)
+#    elev-000-01 (15)  -- B'1111  (1 cm)
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 ELEV_500_00 = 1
+uint8 ELEV_200_00 = 2
+uint8 ELEV_100_00 = 3
+uint8 ELEV_050_00 = 4
+uint8 ELEV_020_00 = 5
+uint8 ELEV_010_00 = 6
+uint8 ELEV_005_00 = 7
+uint8 ELEV_002_00 = 8
+uint8 ELEV_001_00 = 9
+uint8 ELEV_000_50 = 10
+uint8 ELEV_000_20 = 11
+uint8 ELEV_000_10 = 12
+uint8 ELEV_000_05 = 13
+uint8 ELEV_000_02 = 14
+uint8 ELEV_000_01 = 15

--- a/j2735_msgs/msg/FullPositionVector.msg
+++ b/j2735_msgs/msg/FullPositionVector.msg
@@ -1,0 +1,57 @@
+#
+# FullPositionVector.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of FullPositionVector from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# FullPositionVector ::= SEQUENCE {
+#    utcTime             DDateTime OPTIONAL,   -- time with mSec precision
+#    long                Longitude,            -- 1/10th microdegree
+#    lat                 Latitude,             -- 1/10th microdegree
+#    elevation           Elevation  OPTIONAL,  -- units of 0.1 m
+#    heading             Heading OPTIONAL, 
+#    speed               TransmissionAndSpeed OPTIONAL,
+#    posAccuracy         PositionalAccuracy OPTIONAL,
+#    timeConfidence      TimeConfidence OPTIONAL,
+#    posConfidence       PositionConfidenceSet OPTIONAL,
+#    speedConfidence     SpeedandHeadingandThrottleConfidence OPTIONAL, 
+#    ...  
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_HEADING) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_HEADING
+uint16 presence_vector
+
+uint16 HAS_UTC_TIME=1
+uint16 HAS_ELEVATION=2
+uint16 HAS_HEADING=4
+uint16 HAS_SPEED=8
+uint16 HAS_POS_ACCURACY=16
+uint16 HAS_TIME_CONFIDENCE=32
+uint16 HAS_POS_CONFIDENCE=64
+uint16 HAS_SPEED_CONFIDENCE=128
+
+j2735_msgs/DDateTime utc_time
+
+j2735_msgs/Longitude lon
+
+j2735_msgs/Latitude lat
+
+j2735_msgs/Elevation elevation
+
+j2735_msgs/Heading heading
+
+j2735_msgs/TransmissionAndSpeed speed
+
+j2735_msgs/PositionalAccuracy pos_accuracy
+
+j2735_msgs/TimeConfidence time_confidence
+
+j2735_msgs/PositionConfidenceSet pos_confidence
+
+j2735_msgs/SpeedandHeadingandThrottleConfidence speed_confidence

--- a/j2735_msgs/msg/GNSSStatus.msg
+++ b/j2735_msgs/msg/GNSSStatus.msg
@@ -1,0 +1,36 @@
+#
+# GNSSStatus.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of GNSSstatus from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# GNSSstatus ::= BIT STRING {
+#    unavailable               (0), -- Not Equipped or unavailable
+#    isHealthy                 (1),
+#    isMonitored               (2),
+#    baseStationType           (3), -- Set to zero if a moving base station,
+#                                   -- or if a rover device (an OBU),
+#                                   -- set to one if it is a fixed base station 
+#    aPDOPofUnder5             (4), -- A dilution of precision greater than 5
+#    inViewOfUnder5            (5), -- Less than 5 satellites in view
+#    localCorrectionsPresent   (6), -- DGPS type corrections used
+#    networkCorrectionsPresent (7)  -- RTK type corrections used
+#    } (SIZE(8))
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (statuses & BASE_STATION_TYPE) etc.
+# Create with bitwise-or
+# statuses = statuses | BASE_STATION_TYPE
+uint8 statuses
+
+uint8 UNAVAILABLE = 0
+uint8 IS_HEALTHY = 1
+uint8 IS_MONITORED = 2
+uint8 BASE_STATION_TYPE = 4
+uint8 APDOP_OF_UNDER_5 = 8
+uint8 IN_VIEW_OF_UNDER_5 = 16
+uint8 LOCAL_CORRECTIONS_PRESENT = 32
+uint8 NETWORK_CORRECTIONS_PRESENT = 64

--- a/j2735_msgs/msg/Heading.msg
+++ b/j2735_msgs/msg/Heading.msg
@@ -1,0 +1,17 @@
+#
+# Heading.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Heading from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Heading ::= INTEGER (0..28800)
+#  -- LSB of 0.0125 degrees
+#  -- A range of 0 to 359.9875 degrees
+#  -- Convert to degree with factor 0.0125 when field is used
+uint16 heading
+
+uint16 HEADING_UNAVAILABLE = 28800
+uint16 HEADING_MAX = 28798
+uint16 HEADING_MIN = 0

--- a/j2735_msgs/msg/HeadingConfidence.msg
+++ b/j2735_msgs/msg/HeadingConfidence.msg
@@ -1,0 +1,29 @@
+#
+# HeadingConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of HeadingConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# HeadingConfidence ::= ENUMERATED {
+#    unavailable   (0), -- B'000  Not Equipped or unavailable
+#    prec10deg     (1), -- B'010  10     degrees
+#    prec05deg     (2), -- B'011  5      degrees
+#    prec01deg     (3), -- B'100  1      degrees
+#    prec0-1deg    (4), -- B'101  0.1    degrees
+#    prec0-05deg   (5), -- B'110  0.05   degrees
+#    prec0-01deg   (6), -- B'110  0.01   degrees
+#    prec0-0125deg (7)  -- B'111  0.0125 degrees, aligned with heading LSB
+#    }  -- Encoded as a 3 bit value
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 PREC_10_DEG = 1
+uint8 PREC_05_DEG = 2
+uint8 PREC_01_DEG = 3
+uint8 PREC_001_DEG = 4
+uint8 PREC_0005_DEG = 5
+uint8 PREC_0001_DEG = 6
+uint8 PREC_000125_DEG = 7

--- a/j2735_msgs/msg/HumanPropelledType.msg
+++ b/j2735_msgs/msg/HumanPropelledType.msg
@@ -1,0 +1,25 @@
+#
+# HumanPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of HumanPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# HumanPropelledType ::= ENUMERATED {   
+#    unavailable        (0),
+#    otherTypes         (1), -- any method not listed below
+#    onFoot             (2),
+#    skateboard         (3),
+#    pushOrKickScooter  (4),
+#    wheelchair         (5), -- implies manually powered
+#    ...
+# }
+
+uint8 type
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 ON_FOOT=2
+uint8 PUSH_OR_KICK_SCOOTER=3
+uint8 WHEELCHAIR=4
+

--- a/j2735_msgs/msg/Latitude.msg
+++ b/j2735_msgs/msg/Latitude.msg
@@ -1,0 +1,18 @@
+#
+# Latitude.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Latitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# lat Latitude, -- in 1/10th micro degrees
+# Latitude ::= INTEGER (-900000000..900000001)
+#  -- LSB = 1/10 micro degree
+#  -- Providing a range of plus-minus 90 degrees
+#  -- Convert to degree with factor 0.0000001 when field is used
+int32 latitude
+
+int32 LATITUDE_UNAVAILABLE = 900000001
+int32 LATITUDE_MAX = 900000000
+int32 LATITUDE_MIN = -900000000

--- a/j2735_msgs/msg/Longitude.msg
+++ b/j2735_msgs/msg/Longitude.msg
@@ -1,0 +1,18 @@
+#
+# Longitude.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Longitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# long Longitude, -- in 1/10th micro degrees
+# Longitude ::= INTEGER (-1799999999..1800000001)
+#  -- LSB = 1/10 micro degree
+#  -- Providing a range of plus-minus 180 degrees
+#  -- Convert to degree with factor 0.0000001 when field is used
+int32 longitude
+
+int32 LONGITUDE_UNAVAILABLE = 1800000001
+int32 LONGITUDE_MAX = 1800000000
+int32 LONGITUDE_MIN = -1799999999

--- a/j2735_msgs/msg/MotorizedPropelledType.msg
+++ b/j2735_msgs/msg/MotorizedPropelledType.msg
@@ -1,0 +1,26 @@
+#
+# MotorizedPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of MotorizedPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# MotorizedPropelledType ::= ENUMERATED {   
+#    unavailable         (0),
+#    otherTypes          (1), -- any method not listed below
+#    wheelChair          (2),
+#    bicycle             (3),
+#    scooter             (4),
+#    selfBalancingDevice (5), -- such as Segway
+#    ...
+# }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 WHEELCHAIR=2
+uint8 BICYCLE=3
+uint8 SCOOTER=4
+uint8 SELF_BALANCING_DEVICE=5

--- a/j2735_msgs/msg/MsgCount.msg
+++ b/j2735_msgs/msg/MsgCount.msg
@@ -1,0 +1,12 @@
+#
+# MsgCount.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of MsgCount from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# MsgCount ::= INTEGER (0..127)
+uint8 msg_cnt
+
+uint8 MSG_COUNT_MAX = 127

--- a/j2735_msgs/msg/NumberOfParticipantsInCluster.msg
+++ b/j2735_msgs/msg/NumberOfParticipantsInCluster.msg
@@ -1,0 +1,22 @@
+#
+# NumberOfParticipantsInCluster.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of NumberOfParticipantsInCluster from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# NumberOfParticipantsInCluster ::= ENUMERATED { 
+#    unavailable  (0),
+#    small        (1),   -- 2-5
+#    medium       (2),   -- 6-10
+#    large        (3),   -- >10
+#    ...
+#    }
+
+uint8 cluster_size
+
+uint8 UNAVAILABLE=0
+uint8 SMALL=1
+uint8 MEDIUM=2
+uint8 LARGE=3

--- a/j2735_msgs/msg/PSM.msg
+++ b/j2735_msgs/msg/PSM.msg
@@ -1,0 +1,95 @@
+#
+# PSM.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Personal Safety Message (PSM) from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# A BIT STRING defining the presence of optional feilds.
+# Compare with bitwise-and
+# if (presence_vector & HAS_PATH_HISTORY) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_PATH_HISTORY
+uint32 presence_vector
+
+uint32 HAS_ACCEL_SET = 1
+uint32 HAS_PATH_HISTORY = 2
+uint32 HAS_PATH_PREDICTION = 4
+uint32 HAS_PROPULSION = 8
+uint32 HAS_USE_STATE = 16
+uint32 HAS_CROSS_REQUEST = 32
+uint32 HAS_CROSS_STATE = 64
+uint32 HAS_CLUSTER_SIZE = 128
+uint32 HAS_CLUSTER_RADIUS = 256
+uint32 HAS_EVENT_RESPONDER_TYPE = 512
+uint32 HAS_ACTIVITY_TYPE = 1024
+uint32 HAS_ACTIVITY_SUB_TYPE = 2048
+uint32 HAS_ASSIST_TYPE = 4096
+uint32 HAS_SIZING = 8192
+uint32 HAS_ATTACHMENT= 16384
+uint32 HAS_ATTACHMENT_RADIUS = 32768
+uint32 HAS_ANIMAL_TYPE = 65536
+uint32 HAS_REGIONAL_EXTENSION = 131072
+
+j2735_msgs/PersonalDeviceUserType basic_type
+
+j2735_msgs/DSecond sec_mark
+
+j2735_msgs/MsgCount msg_cnt
+
+j2735_msgs/TemporaryID id
+
+j2735_msgs/Position3D position
+
+j2735_msgs/PositionalAccuracy accuracy
+
+j2735_msgs/Velocity speed
+
+j2735_msgs/Heading heading
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+j2735_msgs/AccelerationSet4Way accel_set
+
+j2735_msgs/PathHistory path_history
+
+j2735_msgs/PathPrediction path_prediction
+
+j2735_msgs/PropelledInformation propulsion
+
+j2735_msgs/PersonalDeviceUsageState use_state
+
+j2735_msgs/PersonalCrossingRequest cross_request
+
+j2735_msgs/PersonalCrossingInProgress cross_state
+
+j2735_msgs/NumberOfParticipantsInCluster cluster_size
+
+j2735_msgs/PersonalClusterRadius cluster_radius
+
+j2735_msgs/PublicSafetyEventResponderWorkerType event_responder_type
+
+j2735_msgs/PublicSafetyAndRoadWorkerActivity activity_type
+
+j2735_msgs/PublicSafetyDirectingTrafficSubType activity_sub_type
+
+j2735_msgs/PersonalAssistive assist_type
+
+j2735_msgs/UserSizeAndBehaviour sizing
+
+j2735_msgs/Attachment attachment
+
+j2735_msgs/AttachmentRadius attachment_radius
+
+j2735_msgs/AnimalType animal_type
+
+# TODO Approach to defining regional extensions in ROS has not yet been idenfied. If it is, this field will be updated.
+# regional SEQUENCE (SIZE(1..4)) OF 
+#            j2735_msgs/RegionalExtension {{REGION.Reg-PersonalSafetyMessage}} OPTIONAL,
+#   ...
+#   }

--- a/j2735_msgs/msg/PathHistory.msg
+++ b/j2735_msgs/msg/PathHistory.msg
@@ -1,0 +1,33 @@
+#
+# PathHistory.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PathHistory from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PathHistory ::= SEQUENCE {
+#    initialPosition  FullPositionVector    OPTIONAL,
+#    currGNSSstatus   GNSSstatus            OPTIONAL,   
+#    crumbData  	    PathHistoryPointList,
+#    ...
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_CURR_GNSS_STATUS) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_CURR_GNSS_STATUS
+uint8 presence_vector
+
+uint8 HAS_CURR_GNSS_STATUS = 1
+uint8 HAS_INITIAL_POSITION = 2
+
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+j2735_msgs/FullPositionVector initial_position
+j2735_msgs/GNSSStatus curr_gnss_status

--- a/j2735_msgs/msg/PathPrediction.msg
+++ b/j2735_msgs/msg/PathPrediction.msg
@@ -1,0 +1,26 @@
+#
+# PathPrediction.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PathPrediction from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PathPrediction ::= SEQUENCE {
+#    radiusOfCurve RadiusOfCurvature, 
+#                  -- LSB units of 10cm
+#                  -- straight path to use value of 32767
+#    confidence    Confidence, 
+#                  -- LSB units of 0.5 percent
+#    ...  
+#    }
+
+# RadiusOfCurvature ::= INTEGER (-32767..32767)
+#    -- LSB units of 10cm
+#    -- A straight path to use value of 32767
+int16 radius_of_curvature
+
+
+# Confidence ::= INTEGER (0..200)
+#    -- LSB units of 0.5 percent
+uint8 confidence

--- a/j2735_msgs/msg/PersonalAssistive.msg
+++ b/j2735_msgs/msg/PersonalAssistive.msg
@@ -1,0 +1,30 @@
+#
+# PersonalAssistive.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalAssistive from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalAssistive::= BIT STRING {
+#    unavailable    (0),
+#    otherType      (1),
+#    vision         (2),
+#    hearing        (3),
+#    movement       (4),
+#    cognition      (5)
+#    } (SIZE (6, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (types & OTHER_TYPE) etc.
+# Create with bitwise-or
+# types = types | OTHER_TYPE
+uint8 types
+
+uint8 UNAVAILABLE = 0
+uint8 OTHER_TYPE = 1
+uint8 VISION = 2
+uint8 HEARING = 4
+uint8 MOVEMENT = 8
+uint8 COGNITION = 16

--- a/j2735_msgs/msg/PersonalClusterRadius.msg
+++ b/j2735_msgs/msg/PersonalClusterRadius.msg
@@ -1,0 +1,11 @@
+#
+# PersonalClusterRadius.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalClusterRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalClusterRadius ::= INTEGER (0..100) -- units of meters
+uint8 cluster_radius
+uint8 CLUSTER_RADIUS_MAX = 100

--- a/j2735_msgs/msg/PersonalCrossingInProgress.msg
+++ b/j2735_msgs/msg/PersonalCrossingInProgress.msg
@@ -1,0 +1,12 @@
+#
+# PersonalCrossingInProgress.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalCrossingInProgress from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalCrossingInProgress ::= BOOLEAN -- Use:
+#    -- True  = Yes, is in maneuver
+#    -- False = No
+bool cross_state

--- a/j2735_msgs/msg/PersonalCrossingRequest.msg
+++ b/j2735_msgs/msg/PersonalCrossingRequest.msg
@@ -1,0 +1,13 @@
+#
+# PersonalCrossingRequest.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalCrossingRequest from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalCrossingRequest ::= BOOLEAN 
+#    -- Use:
+#    -- True  = On  (request crossing)
+#    -- False = Off (no request)
+bool cross_request

--- a/j2735_msgs/msg/PersonalDeviceUsageState.msg
+++ b/j2735_msgs/msg/PersonalDeviceUsageState.msg
@@ -1,0 +1,40 @@
+#
+# PersonalDeviceUsageState.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalDeviceUsageState from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalDeviceUsageState ::= BIT STRING {  
+#    unavailable      (0), -- Not specified
+#    other            (1), -- Used for states not defined below
+#    idle             (2), -- Human is not interacting with device  
+#    listeningToAudio (3), -- Any audio source other then calling 
+#    typing           (4), -- Including texting, entering addresses 
+#                          -- and other manual input activity 
+#    calling          (5),   
+#    playingGames     (6),   
+#    reading          (7),   
+#    viewing          (8)  -- Watching dynamic content, including following 
+#                          -- navigation prompts, viewing videos or other 
+#                          -- visual contents that are not static
+#    } (SIZE (9, ...))
+#    -- All bits shall be set to zero when unknown state
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (states & IDLE) etc.
+# Create with bitwise-or
+# states = states | IDLE
+uint16 states
+
+uint16 UNAVAILABLE=0
+uint16 OTHER=1
+uint16 IDLE=2
+uint16 LISTENING_TO_AUDIO=4
+uint16 TYPING=8
+uint16 CALLING=16
+uint16 PLAYING_GAMES=32
+uint16 READING=64
+uint16 VIEWING=128

--- a/j2735_msgs/msg/PersonalDeviceUserType.msg
+++ b/j2735_msgs/msg/PersonalDeviceUserType.msg
@@ -1,0 +1,26 @@
+#
+# PersonalDeviceUserType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalDeviceUserType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# PersonalDeviceUserType ::= ENUMERATED { 
+#    unavailable           (0),
+#    aPEDESTRIAN           (1), -- Further details may be provided elsewhere
+#    aPEDALCYCLIST         (2), -- Presumed to be human propelled, 
+#                               -- unless PropelledInformation indicates motorized
+#    aPUBLICSAFETYWORKER   (3),
+#    anANIMAL              (4),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 A_PEDESTRIAN=1
+uint8 A_PEDALCYCLIST=2
+uint8 A_PUBLIC_SAFETY_WORKER=3
+uint8 AN_ANIMAL=4

--- a/j2735_msgs/msg/PositionConfidence.msg
+++ b/j2735_msgs/msg/PositionConfidence.msg
@@ -1,0 +1,45 @@
+#
+# PositionConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PositionConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PositionConfidence ::= ENUMERATED {
+#    unavailable (0),  -- B'0000  Not Equipped or unavailable
+#    a500m   (1), -- B'0001  500m  or about 5 * 10 ^ -3 decimal degrees
+#    a200m   (2), -- B'0010  200m  or about 2 * 10 ^ -3 decimal degrees
+#    a100m   (3), -- B'0011  100m  or about 1 * 10 ^ -3 decimal degrees
+#    a50m    (4), -- B'0100  50m   or about 5 * 10 ^ -4 decimal degrees 
+#    a20m    (5), -- B'0101  20m   or about 2 * 10 ^ -4 decimal degrees 
+#    a10m    (6), -- B'0110  10m   or about 1 * 10 ^ -4 decimal degrees 
+#    a5m     (7), -- B'0111  5m    or about 5 * 10 ^ -5 decimal degrees 
+#    a2m     (8), -- B'1000  2m    or about 2 * 10 ^ -5 decimal degrees 
+#    a1m     (9), -- B'1001  1m    or about 1 * 10 ^ -5 decimal degrees 
+#    a50cm  (10), -- B'1010  0.50m or about 5 * 10 ^ -6 decimal degrees 
+#    a20cm  (11), -- B'1011  0.20m or about 2 * 10 ^ -6 decimal degrees 
+#    a10cm  (12), -- B'1100  0.10m or about 1 * 10 ^ -6 decimal degrees 
+#    a5cm   (13), -- B'1101  0.05m or about 5 * 10 ^ -7 decimal degrees 
+#    a2cm   (14), -- B'1110  0.02m or about 2 * 10 ^ -7 decimal degrees 
+#    a1cm   (15)  -- B'1111  0.01m or about 1 * 10 ^ -7 decimal degrees 
+#    } 
+
+uint8 confidence
+
+uint8 UNAVAILABLE=0
+uint8 A500M=1
+uint8 A200M=2
+uint8 A100M=3
+uint8 A50M=4
+uint8 A20M=5
+uint8 A10M=6
+uint8 A5M=7
+uint8 A2M=8
+uint8 A1M=9
+uint8 A50CM=10
+uint8 A20CM=11
+uint8 A10CM=12
+uint8 A5CM=13
+uint8 A2CM=14
+uint8 A1CM=15

--- a/j2735_msgs/msg/PositionConfidenceSet.msg
+++ b/j2735_msgs/msg/PositionConfidenceSet.msg
@@ -1,0 +1,16 @@
+#
+# PositionConfidenceSet.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PositionConfidenceSet from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PositionConfidenceSet ::= SEQUENCE {
+#    pos        PositionConfidence, -- for both horizontal directions
+#    elevation  ElevationConfidence 
+#    }
+
+j2735_msgs/PositionConfidence pos
+
+j2735_msgs/ElevationConfidence elevation

--- a/j2735_msgs/msg/PropelledInformation.msg
+++ b/j2735_msgs/msg/PropelledInformation.msg
@@ -1,0 +1,25 @@
+#
+# PropelledInformation.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PropelledInformation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PropelledInformation ::= CHOICE {
+#    human   HumanPropelledType, -- PersonalDeviceUserType would be a aPEDESTRIAN
+#    animal  AnimalPropelledType,
+#    motor   MotorizedPropelledType,
+#    ...
+# }    
+
+uint8 choice
+
+uint8 CHOICE_HUMAN=0
+uint8 CHOICE_ANIMAL=1
+uint8 CHOICE_MOTOR=2
+
+# Following fields selected by the choice enum
+j2735_msgs/HumanPropelledType human
+j2735_msgs/AnimalPropelledType animal
+j2735_msgs/MotorizedPropelledType motor

--- a/j2735_msgs/msg/PublicSafetyAndRoadWorkerActivity.msg
+++ b/j2735_msgs/msg/PublicSafetyAndRoadWorkerActivity.msg
@@ -1,0 +1,52 @@
+#
+# PublicSafetyAndRoadWorkerActivity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PropelledInformation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyAndRoadWorkerActivity ::= BIT STRING {
+#    unavailable          (0), -- Not specified
+#    workingOnRoad        (1), -- Road workers on foot, in or out of 
+#                              -- a closure, performing activities like: 
+#                              -- construction, land surveying, 
+#                              -- trash removal, or site inspection.
+#    settingUpClosures    (2), -- Road workers on foot performing
+#                              -- activities like: setting up signs, 
+#                              -- placing cones/barrels/pylons, or placing 
+#                              -- flares.  Note: People are in the road 
+#                              -- redirecting traffic, but the closure is 
+#                              -- not complete, so utmost care is required 
+#                              -- to determine the allowed path to take to 
+#                              -- avoid entering the work zone and/or 
+#                              -- harming the workers.
+#    respondingToEvents   (3), -- Public safety or other road workers on
+#                              -- foot performing activities like: treating 
+#                              -- injured people, putting out fires, 
+#                              -- cleaning chemical spills, aiding disabled 
+#                              -- vehicles, criminal investigations, 
+#                              -- or animal control.  Note: These events tend 
+#                              -- to be more dynamic than workingOnRoad
+#    directingTraffic     (4), -- Public safety or other road workers on
+#                              -- foot directing traffic in situations like: 
+#                              -- a traffic signal out of operation, 
+#                              -- a construction or crash site with a short 
+#                              -- term lane closure, a single lane flagging 
+#                              -- operation, or ingress/egress to a special event.
+#    otherActivities      (5)  -- Designated by regional authorities  
+#    } (SIZE (6, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (activities & SETTING_UP_CLOSURES) etc.
+# Create with bitwise-or
+# activities = activities | SETTING_UP_CLOSURES
+uint8 activities
+
+uint8 UNAVAILABLE=0
+uint8 WORKING_ON_ROAD=1
+uint8 SETTING_UP_CLOSURES=2
+uint8 RESPONDING_TO_EVENTS=4
+uint8 DIRECTING_TRAFFIC=8
+uint8 OTHER_ACTIVITIES=16

--- a/j2735_msgs/msg/PublicSafetyDirectingTrafficSubType.msg
+++ b/j2735_msgs/msg/PublicSafetyDirectingTrafficSubType.msg
@@ -1,0 +1,48 @@
+#
+# PublicSafetyAndRoadWorkerActivity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyDirectingTrafficSubType ::= BIT STRING {
+#    unavailable                        (0),
+#       -- Default.  
+#       -- to be used if unknown or if the worker type is not otherwise identified
+#    policeAndTrafficOfficers           (1), 
+#       -- Law enforcement officers, including traffic control officers,
+#       -- and adult school crossing guards.
+#    trafficControlPersons              (2), 
+#      -- Road workers with special equipment for directing traffic.
+#    railroadCrossingGuards             (3), 
+#      -- Railroad crossing guards who notify motorists of approaching trains 
+#      -- at locations like private roads or driveways crossing train tracks 
+#      -- and where automated equipment is disabled or not present. 
+#    civilDefenseNationalGuardMilitaryPolice (4),
+#         -- while performing their regular duties or during National
+#      -- or local emergencies
+#    emergencyOrganizationPersonnel     (5),
+#       -- Personnel belonging to emergency response organizations such as
+#       -- fire departments, hospitals, river rescue, or associated with
+#       -- emergency vehicles including ambulances as designated by the 
+#       -- regional authority (relating to designation of emergency vehicles)
+#       -- while performing their duties.
+#    highwayServiceVehiclePersonnel     (6)
+#       -- Associated with tow trucks and road service vehicles.
+#    } (SIZE (7, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (sub_types & POLICE_AND_TRAFFIC_OFFICERS) etc.
+# Create with bitwise-or
+# sub_types = sub_types | POLICE_AND_TRAFFIC_OFFICERS
+uint8 sub_types
+
+uint8 UNAVAILABLE = 0
+uint8 POLICE_AND_TRAFFIC_OFFICERS = 1
+uint8 TRAFFIC_CONTROL_PERSONS = 2
+uint8 RAILROAD_CROSSING_GURADS = 4
+uint8 CIVIL_DEFENSE_NATIONAL_GUARD_MILITARY_POLICE = 8
+uint8 EMERGENCY_ORGANIZATION_PERSONNEL = 16
+uint8 HIGHWAY_SERVICE_VEHICLE_PERSONNEL = 32

--- a/j2735_msgs/msg/PublicSafetyEventResponderWorkerType.msg
+++ b/j2735_msgs/msg/PublicSafetyEventResponderWorkerType.msg
@@ -1,0 +1,30 @@
+#
+# PublicSafetyEventResponderWorkerType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyEventResponderWorkerType ::= ENUMERATED { 
+#    unavailable               (0),
+#    towOperater               (1),
+#    fireAndEMSWorker          (2),
+#    aDOTWorker                (3),
+#    lawEnforcement            (4),
+#    hazmatResponder           (5), -- also any toxicSubstanceCleanupCrew
+#    animalControlWorker       (6),
+#    otherPersonnel            (7),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 TOW_OPERATOR=1
+uint8 FIRE_EMS_WORKER=2
+uint8 ADOT_WORKER=3
+uint8 LAW_ENFORCEMENT=4
+uint8 HAZMAT_RESPONDER=5
+uint8 ANIMAL_CONTROL_WORKER=6
+uint8 OTHER_PERSONNEL=7

--- a/j2735_msgs/msg/SpeedandHeadingandThrottleConfidence.msg
+++ b/j2735_msgs/msg/SpeedandHeadingandThrottleConfidence.msg
@@ -1,0 +1,17 @@
+#
+# SpeedandHeadingandThrottleConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of SpeedandHeadingandThrottleConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# SpeedandHeadingandThrottleConfidence ::= SEQUENCE {
+#    heading   HeadingConfidence,    
+#    speed     SpeedConfidence,      
+#    throttle  ThrottleConfidence    
+#    }
+
+j2735_msgs/HeadingConfidence heading
+j2735_msgs/SpeedConfidence speed
+j2735_msgs/ThrottleConfidence throttle

--- a/j2735_msgs/msg/TemporaryID.msg
+++ b/j2735_msgs/msg/TemporaryID.msg
@@ -1,0 +1,14 @@
+#
+# TemporaryID.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TemporaryID from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TemporaryID ::= OCTET STRING (SIZE(4))
+
+uint8[] id
+
+#TemporaryID will change every 3000 seconds.
+uint16 ID_TIME_MAX = 3000

--- a/j2735_msgs/msg/ThrottleConfidence.msg
+++ b/j2735_msgs/msg/ThrottleConfidence.msg
@@ -1,0 +1,21 @@
+#
+# ThrottleConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of ThrottleConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# ThrottleConfidence ::= ENUMERATED {
+#    unavailable     (0), -- B'00  Not Equipped or unavailable
+#    prec10percent   (1), -- B'01  10  percent Confidence level
+#    prec1percent    (2), -- B'10  1   percent Confidence level
+#    prec0-5percent  (3)  -- B'11  0.5 percent Confidence level
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 PREC_10_PERCENT = 1
+uint8 PREC_1_PERCENT = 2
+uint8 PREC_05_PERCENT = 3

--- a/j2735_msgs/msg/TimeConfidence.msg
+++ b/j2735_msgs/msg/TimeConfidence.msg
@@ -1,0 +1,96 @@
+#
+# TimeConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TimeConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TimeConfidence ::= ENUMERATED {
+#    unavailable              (0), -- Not Equipped or unavailable
+#    time-100-000             (1), -- Better than  100 Seconds
+#    time-050-000             (2), -- Better than  50 Seconds
+#    time-020-000             (3), -- Better than  20 Seconds
+#    time-010-000             (4), -- Better than  10 Seconds
+#    time-002-000             (5), -- Better than  2 Seconds
+#    time-001-000             (6), -- Better than  1 Second
+#    time-000-500             (7), -- Better than  0.5 Seconds
+#    time-000-200             (8), -- Better than  0.2 Seconds
+#    time-000-100             (9), -- Better than  0.1 Seconds
+#    time-000-050            (10), -- Better than  0.05 Seconds
+#    time-000-020            (11), -- Better than  0.02 Seconds
+#    time-000-010            (12), -- Better than  0.01 Seconds
+#    time-000-005            (13), -- Better than  0.005 Seconds
+#    time-000-002            (14), -- Better than  0.002 Seconds
+#    time-000-001            (15), -- Better than  0.001 Seconds
+#                                  -- Better than  one millisecond
+#    time-000-000-5          (16), -- Better than  0.000,5 Seconds
+#    time-000-000-2          (17), -- Better than  0.000,2 Seconds
+#    time-000-000-1          (18), -- Better than  0.000,1 Seconds
+#    time-000-000-05         (19), -- Better than  0.000,05 Seconds
+#    time-000-000-02         (20), -- Better than  0.000,02 Seconds
+#    time-000-000-01         (21), -- Better than  0.000,01 Seconds
+#    time-000-000-005        (22), -- Better than  0.000,005 Seconds
+#    time-000-000-002        (23), -- Better than  0.000,002 Seconds
+#    time-000-000-001        (24), -- Better than  0.000,001 Seconds 
+#                                  -- Better than  one micro second
+#    time-000-000-000-5      (25), -- Better than  0.000,000,5 Seconds
+#    time-000-000-000-2      (26), -- Better than  0.000,000,2 Seconds
+#    time-000-000-000-1      (27), -- Better than  0.000,000,1 Seconds
+#    time-000-000-000-05     (28), -- Better than  0.000,000,05 Seconds
+#    time-000-000-000-02     (29), -- Better than  0.000,000,02 Seconds
+#    time-000-000-000-01     (30), -- Better than  0.000,000,01 Seconds
+#    time-000-000-000-005    (31), -- Better than  0.000,000,005 Seconds
+#    time-000-000-000-002    (32), -- Better than  0.000,000,002 Seconds
+#    time-000-000-000-001    (33), -- Better than  0.000,000,001 Seconds
+#                                  -- Better than  one nano second
+#    time-000-000-000-000-5  (34), -- Better than  0.000,000,000,5 Seconds
+#    time-000-000-000-000-2  (35), -- Better than  0.000,000,000,2 Seconds
+#    time-000-000-000-000-1  (36), -- Better than  0.000,000,000,1 Seconds
+#    time-000-000-000-000-05 (37), -- Better than  0.000,000,000,05 Seconds
+#    time-000-000-000-000-02 (38), -- Better than  0.000,000,000,02 Seconds
+#    time-000-000-000-000-01 (39)  -- Better than  0.000,000,000,01 Seconds 
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 TIME_100_000 = 1
+uint8 TIME_050_000 = 2
+uint8 TIME_020_000 = 3
+uint8 TIME_010_000 = 4
+uint8 TIME_002_000 = 5
+uint8 TIME_001_000 = 6
+uint8 TIME_000_500 = 7
+uint8 TIME_000_200 = 8
+uint8 TIME_000_100 = 9
+uint8 TIME_000_050 = 10
+uint8 TIME_000_020 = 11
+uint8 TIME_000_010 = 12
+uint8 TIME_000_005 = 13
+uint8 TIME_000_002 = 14
+uint8 TIME_000_001 = 15
+uint8 TIME_000_000_5 = 16
+uint8 TIME_000_000_2 = 17
+uint8 TIME_000_000_1 = 18
+uint8 TIME_000_000_05 = 19
+uint8 TIME_000_000_02 = 20
+uint8 TIME_000_000_01 = 21
+uint8 TIME_000_000_005 = 22
+uint8 TIME_000_000_002 = 23
+uint8 TIME_000_000_001 = 24
+uint8 TIME_000_000_000_5 = 25
+uint8 TIME_000_000_000_2 = 26
+uint8 TIME_000_000_000_1 = 27
+uint8 TIME_000_000_000_05 = 28
+uint8 TIME_000_000_000_02 = 29
+uint8 TIME_000_000_000_01 = 30
+uint8 TIME_000_000_000_005 = 31
+uint8 TIME_000_000_000_002 = 32
+uint8 TIME_000_000_000_001 = 33
+uint8 TIME_000_000_000_000_5 = 34
+uint8 TIME_000_000_000_000_2 = 35
+uint8 TIME_000_000_000_000_1 = 36
+uint8 TIME_000_000_000_000_05 = 37
+uint8 TIME_000_000_000_000_02 = 38
+uint8 TIME_000_000_000_000_01 = 39

--- a/j2735_msgs/msg/TransmissionAndSpeed.msg
+++ b/j2735_msgs/msg/TransmissionAndSpeed.msg
@@ -1,0 +1,16 @@
+#
+# TransmissionAndSpeed.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TransmissionAndSpeed from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TransmissionAndSpeed ::= SEQUENCE {
+#    transmisson   TransmissionState,
+#    speed         Velocity
+#    }
+
+j2735_msgs/TransmissionState transmission
+
+j2735_msgs/Velocity speed

--- a/j2735_msgs/msg/UserSizeAndBehaviour.msg
+++ b/j2735_msgs/msg/UserSizeAndBehaviour.msg
@@ -1,0 +1,28 @@
+#
+# UserSizeAndBehaviour.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# UserSizeAndBehaviour ::= BIT STRING { 
+#    unavailable                     (0),
+#    smallStature                    (1), -- less than 150 cm high
+#    largeStature                    (2),
+#    erraticMoving                   (3), 
+#    slowMoving                      (4)  -- those who move a bit slowly
+#    } (SIZE (5, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (sizes_and_behaviors & SMALL_STATURE) etc.
+# Create with bitwise-or
+# sizes_and_behaviors = activities | SMALL_STATURE
+uint8 sizes_and_behaviors
+
+uint8 UNAVAILABLE = 0
+uint8 SMALL_STATURE = 1
+uint8 LARGE_STATURE = 2
+uint8 ERRATIC_MOVING = 4
+uint8 SLOW_MOVING = 8

--- a/j2735_msgs/msg/Velocity.msg
+++ b/j2735_msgs/msg/Velocity.msg
@@ -1,0 +1,18 @@
+#
+# Velocity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Velocity from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Velocity ::= INTEGER (0..8191) -- Units of 0.02 m/s
+#     -- The value 8191 indicates that 
+#     -- velocity is unavailable
+
+uint16 velocity
+
+uint16 MIN=0
+uint16 MAX=8190
+uint16 UNAVAILABLE=8191
+

--- a/j2735_v2x_msgs/msg/AnimalPropelledType.msg
+++ b/j2735_v2x_msgs/msg/AnimalPropelledType.msg
@@ -1,0 +1,22 @@
+#
+# AnimalPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AnimalPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AnimalPropelledType ::= ENUMERATED {   
+#    unavailable         (0),
+#    otherTypes          (1), -- any method not listed below
+#    animalMounted       (2), -- as in horseback          
+#    animalDrawnCarriage (3),
+#    ...
+# }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 ANIMAL_MOUNTED=2
+uint8 ANIMAL_DRAWN_CARRIAGE=3

--- a/j2735_v2x_msgs/msg/AnimalType.msg
+++ b/j2735_v2x_msgs/msg/AnimalType.msg
@@ -1,0 +1,22 @@
+#
+# AnimalType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AnimalType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AnimalType ::= ENUMERATED { 
+#    unavailable    (0), 
+#    serviceUse     (1),  -- Includes guide or police animals
+#    pet            (2),
+#    farm           (3),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 SERVICE_USE=1
+uint8 PET=2
+uint8 FARM=3

--- a/j2735_v2x_msgs/msg/Attachment.msg
+++ b/j2735_v2x_msgs/msg/Attachment.msg
@@ -1,0 +1,28 @@
+#
+# Attachment.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Attachment from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Attachment ::= ENUMERATED { 
+#    unavailable                  (0), -- has some unknown attachment type
+#    stroller                     (1),
+#    bicycleTrailer               (2),
+#    cart                         (3),
+#    wheelchair                   (4), 
+#    otherWalkAssistAttachments   (5),
+#    pet                          (6),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE = 0
+uint8 STROLLER = 1
+uint8 BICYCLE_TRAILER = 2
+uint8 CART = 3
+uint8 WHEELCHAIR = 4
+uint8 OTHER_WALK_ASSIST_ATTACHMENTS = 5
+uint8 PET = 6

--- a/j2735_v2x_msgs/msg/AttachmentRadius.msg
+++ b/j2735_v2x_msgs/msg/AttachmentRadius.msg
@@ -1,0 +1,12 @@
+#
+# AttachmentRadius.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of AttachmentRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# AttachmentRadius ::= INTEGER (0..200) -- In LSB units of one decimeter
+uint8 attachment_radius
+
+uint8 ATTACHMENT_RADIUS_MAX = 200

--- a/j2735_v2x_msgs/msg/DDateTime.msg
+++ b/j2735_v2x_msgs/msg/DDateTime.msg
@@ -1,0 +1,49 @@
+#
+# DDateTime.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DDateTime from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# DDateTime ::= SEQUENCE {
+#    year    DYear    OPTIONAL,    
+#    month   DMonth   OPTIONAL,   
+#    day     DDay     OPTIONAL,  
+#    hour    DHour    OPTIONAL,   
+#    minute  DMinute  OPTIONAL,  
+#    second  DSecond  OPTIONAL,  
+#    offset  DOffset  OPTIONAL -- time zone
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & YEAR) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | YEAR
+uint8 presence_vector
+
+uint8 UNSET = 0
+uint8 YEAR=1
+uint8 MONTH=2
+uint8 DAY=4
+uint8 HOUR=8
+uint8 MINUTE=16
+uint8 SECOND=32
+uint8 OFFSET=64
+
+j2735_v2x_msgs/DYear year
+
+j2735_v2x_msgs/DMonth month
+
+j2735_v2x_msgs/DDay day
+
+j2735_v2x_msgs/DHour hour
+
+j2735_v2x_msgs/DMinute minute
+
+j2735_v2x_msgs/DSecond second
+
+j2735_v2x_msgs/DOffset offset
+

--- a/j2735_v2x_msgs/msg/DDay.msg
+++ b/j2735_v2x_msgs/msg/DDay.msg
@@ -1,0 +1,13 @@
+#
+# DDay.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DDay from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DDay ::= INTEGER (0..31)  -- units of days
+uint8 day
+
+uint8 UNAVAILABLE=0
+uint8 MAX=31

--- a/j2735_v2x_msgs/msg/DHour.msg
+++ b/j2735_v2x_msgs/msg/DHour.msg
@@ -1,0 +1,17 @@
+#
+# DHour.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DHour from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DHour ::= INTEGER (0..31) -- units of hours
+# Hour of day is 0-23, 31 denotes unvailable and 24-30 are reserved for transit schedule adherence
+uint8 hour
+
+uint8 HOUR_OF_DAY_MIN=0
+uint8 HOUR_OF_DAY_MAX=31
+uint8 TRANSITE_SCHEDULE_ADHERENCE_START=24
+uint8 TRANSITE_SCHEDULE_ADHERENCE_END=30
+uint8 UNAVAILABLE=31

--- a/j2735_v2x_msgs/msg/DMinute.msg
+++ b/j2735_v2x_msgs/msg/DMinute.msg
@@ -1,0 +1,15 @@
+#
+# DMinute.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DMinute from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DMinute ::= INTEGER (0..60) -- units of minutes
+
+uint8 minute
+
+uint8 MINUTE_IN_HOUR_MIN=0
+uint8 MINUTE_IN_HOUR_MAX=59
+uint8 UNAVAILABLE=60

--- a/j2735_v2x_msgs/msg/DMonth.msg
+++ b/j2735_v2x_msgs/msg/DMonth.msg
@@ -1,0 +1,13 @@
+#
+# DMonth.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DMonth from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DMonth ::= INTEGER (0..12) -- units of months
+uint8 month
+
+uint8 UNAVAILABLE=0
+uint8 MAX=12

--- a/j2735_v2x_msgs/msg/DOffset.msg
+++ b/j2735_v2x_msgs/msg/DOffset.msg
@@ -1,0 +1,15 @@
+#
+# DOffset.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DOffset from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DOffset ::= INTEGER (-840..840) -- units of minutes from UTC time
+
+int16 offset_minute
+
+int16 MIN=-840
+int16 MAX=840
+int16 UNAVAILABLE=0

--- a/j2735_v2x_msgs/msg/DSecond.msg
+++ b/j2735_v2x_msgs/msg/DSecond.msg
@@ -1,0 +1,19 @@
+#
+# DSecond.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DSecond from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DSecond ::= INTEGER (0..65535) -- units of milliseconds
+
+uint16 millisecond
+
+uint16 MILLISEC_WITHIN_MINUTE_NON_LEAP_MIN=0
+uint16 MILLISEC_WITHIN_MINUTE_NON_LEAP_MAX=59999
+uint16 MILLISEC_WITHIN_MINUTE_LEAP_MIN=60000
+uint16 MILLISEC_WITHIN_MINUTE_LEAP_MAX=60999
+uint16 RESERVED_MIN=61000
+uint16 RESERVED_MAX=65534
+uint16 UNAVAILABLE=65535

--- a/j2735_v2x_msgs/msg/DYear.msg
+++ b/j2735_v2x_msgs/msg/DYear.msg
@@ -1,0 +1,13 @@
+#
+# DYear.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of DYear from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# DYear ::= INTEGER (0..4095) -- units of years
+uint16 year
+
+uint16 UNAVAILABLE=0
+uint16 MAX=4095

--- a/j2735_v2x_msgs/msg/Elevation.msg
+++ b/j2735_v2x_msgs/msg/Elevation.msg
@@ -1,0 +1,19 @@
+#
+# Elevation.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Elevation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# elevation Elevation, -- in 10 cm units
+# Elevation ::= INTEGER (-4096..61439)
+#  -- In units of 10 cm steps above or below the reference ellipsoid
+#  -- Providing a range of -409.5 to + 6143.9 meters
+#  -- The value -4096 shall be used when Unknown is to be sent
+#  -- Convert to meter with factor 0.1 when field is used
+int32 elevation
+
+int32 ELEVATION_UNAVAILABLE = -4096
+int32 ELEVATION_MAX = 61439
+int32 ELEVATION_MIN = -4095

--- a/j2735_v2x_msgs/msg/ElevationConfidence.msg
+++ b/j2735_v2x_msgs/msg/ElevationConfidence.msg
@@ -1,0 +1,45 @@
+#
+# ElevationConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of ElevationConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# ElevationConfidence ::= ENUMERATED {
+#    unavailable (0),  -- B'0000  Not Equipped or unavailable
+#    elev-500-00 (1),  -- B'0001  (500 m)
+#    elev-200-00 (2),  -- B'0010  (200 m)
+#    elev-100-00 (3),  -- B'0011  (100 m)
+#    elev-050-00 (4),  -- B'0100  (50 m)
+#    elev-020-00 (5),  -- B'0101  (20 m)
+#    elev-010-00 (6),  -- B'0110  (10 m)
+#    elev-005-00 (7),  -- B'0111  (5 m)
+#    elev-002-00 (8),  -- B'1000  (2 m)
+#    elev-001-00 (9),  -- B'1001  (1 m)
+#    elev-000-50 (10), -- B'1010  (50 cm)
+#    elev-000-20 (11), -- B'1011  (20 cm)
+#    elev-000-10 (12), -- B'1100  (10 cm)
+#    elev-000-05 (13), -- B'1101  (5 cm)
+#    elev-000-02 (14), -- B'1110  (2 cm)
+#    elev-000-01 (15)  -- B'1111  (1 cm)
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 ELEV_500_00 = 1
+uint8 ELEV_200_00 = 2
+uint8 ELEV_100_00 = 3
+uint8 ELEV_050_00 = 4
+uint8 ELEV_020_00 = 5
+uint8 ELEV_010_00 = 6
+uint8 ELEV_005_00 = 7
+uint8 ELEV_002_00 = 8
+uint8 ELEV_001_00 = 9
+uint8 ELEV_000_50 = 10
+uint8 ELEV_000_20 = 11
+uint8 ELEV_000_10 = 12
+uint8 ELEV_000_05 = 13
+uint8 ELEV_000_02 = 14
+uint8 ELEV_000_01 = 15

--- a/j2735_v2x_msgs/msg/FullPositionVector.msg
+++ b/j2735_v2x_msgs/msg/FullPositionVector.msg
@@ -1,0 +1,57 @@
+#
+# FullPositionVector.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of FullPositionVector from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# FullPositionVector ::= SEQUENCE {
+#    utcTime             DDateTime OPTIONAL,   -- time with mSec precision
+#    long                Longitude,            -- 1/10th microdegree
+#    lat                 Latitude,             -- 1/10th microdegree
+#    elevation           Elevation  OPTIONAL,  -- units of 0.1 m
+#    heading             Heading OPTIONAL, 
+#    speed               TransmissionAndSpeed OPTIONAL,
+#    posAccuracy         PositionalAccuracy OPTIONAL,
+#    timeConfidence      TimeConfidence OPTIONAL,
+#    posConfidence       PositionConfidenceSet OPTIONAL,
+#    speedConfidence     SpeedandHeadingandThrottleConfidence OPTIONAL, 
+#    ...  
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_HEADING) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_HEADING
+uint16 presence_vector
+
+uint16 HAS_UTC_TIME=1
+uint16 HAS_ELEVATION=2
+uint16 HAS_HEADING=4
+uint16 HAS_SPEED=8
+uint16 HAS_POS_ACCURACY=16
+uint16 HAS_TIME_CONFIDENCE=32
+uint16 HAS_POS_CONFIDENCE=64
+uint16 HAS_SPEED_CONFIDENCE=128
+
+j2735_v2x_msgs/DDateTime utc_time
+
+j2735_v2x_msgs/Longitude lon
+
+j2735_v2x_msgs/Latitude lat
+
+j2735_v2x_msgs/Elevation elevation
+
+j2735_v2x_msgs/Heading heading
+
+j2735_v2x_msgs/TransmissionAndSpeed speed
+
+j2735_v2x_msgs/PositionalAccuracy pos_accuracy
+
+j2735_v2x_msgs/TimeConfidence time_confidence
+
+j2735_v2x_msgs/PositionConfidenceSet pos_confidence
+
+j2735_v2x_msgs/SpeedandHeadingandThrottleConfidence speed_confidence

--- a/j2735_v2x_msgs/msg/GNSSStatus.msg
+++ b/j2735_v2x_msgs/msg/GNSSStatus.msg
@@ -1,0 +1,36 @@
+#
+# GNSSStatus.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of GNSSstatus from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# GNSSstatus ::= BIT STRING {
+#    unavailable               (0), -- Not Equipped or unavailable
+#    isHealthy                 (1),
+#    isMonitored               (2),
+#    baseStationType           (3), -- Set to zero if a moving base station,
+#                                   -- or if a rover device (an OBU),
+#                                   -- set to one if it is a fixed base station 
+#    aPDOPofUnder5             (4), -- A dilution of precision greater than 5
+#    inViewOfUnder5            (5), -- Less than 5 satellites in view
+#    localCorrectionsPresent   (6), -- DGPS type corrections used
+#    networkCorrectionsPresent (7)  -- RTK type corrections used
+#    } (SIZE(8))
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (statuses & BASE_STATION_TYPE) etc.
+# Create with bitwise-or
+# statuses = statuses | BASE_STATION_TYPE
+uint8 statuses
+
+uint8 UNAVAILABLE = 0
+uint8 IS_HEALTHY = 1
+uint8 IS_MONITORED = 2
+uint8 BASE_STATION_TYPE = 4
+uint8 APDOP_OF_UNDER_5 = 8
+uint8 IN_VIEW_OF_UNDER_5 = 16
+uint8 LOCAL_CORRECTIONS_PRESENT = 32
+uint8 NETWORK_CORRECTIONS_PRESENT = 64

--- a/j2735_v2x_msgs/msg/Heading.msg
+++ b/j2735_v2x_msgs/msg/Heading.msg
@@ -1,0 +1,17 @@
+#
+# Heading.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Heading from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Heading ::= INTEGER (0..28800)
+#  -- LSB of 0.0125 degrees
+#  -- A range of 0 to 359.9875 degrees
+#  -- Convert to degree with factor 0.0125 when field is used
+uint16 heading
+
+uint16 HEADING_UNAVAILABLE = 28800
+uint16 HEADING_MAX = 28798
+uint16 HEADING_MIN = 0

--- a/j2735_v2x_msgs/msg/HeadingConfidence.msg
+++ b/j2735_v2x_msgs/msg/HeadingConfidence.msg
@@ -1,0 +1,29 @@
+#
+# HeadingConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of HeadingConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# HeadingConfidence ::= ENUMERATED {
+#    unavailable   (0), -- B'000  Not Equipped or unavailable
+#    prec10deg     (1), -- B'010  10     degrees
+#    prec05deg     (2), -- B'011  5      degrees
+#    prec01deg     (3), -- B'100  1      degrees
+#    prec0-1deg    (4), -- B'101  0.1    degrees
+#    prec0-05deg   (5), -- B'110  0.05   degrees
+#    prec0-01deg   (6), -- B'110  0.01   degrees
+#    prec0-0125deg (7)  -- B'111  0.0125 degrees, aligned with heading LSB
+#    }  -- Encoded as a 3 bit value
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 PREC_10_DEG = 1
+uint8 PREC_05_DEG = 2
+uint8 PREC_01_DEG = 3
+uint8 PREC_001_DEG = 4
+uint8 PREC_0005_DEG = 5
+uint8 PREC_0001_DEG = 6
+uint8 PREC_000125_DEG = 7

--- a/j2735_v2x_msgs/msg/HumanPropelledType.msg
+++ b/j2735_v2x_msgs/msg/HumanPropelledType.msg
@@ -1,0 +1,25 @@
+#
+# HumanPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of HumanPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# HumanPropelledType ::= ENUMERATED {   
+#    unavailable        (0),
+#    otherTypes         (1), -- any method not listed below
+#    onFoot             (2),
+#    skateboard         (3),
+#    pushOrKickScooter  (4),
+#    wheelchair         (5), -- implies manually powered
+#    ...
+# }
+
+uint8 type
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 ON_FOOT=2
+uint8 PUSH_OR_KICK_SCOOTER=3
+uint8 WHEELCHAIR=4
+

--- a/j2735_v2x_msgs/msg/Latitude.msg
+++ b/j2735_v2x_msgs/msg/Latitude.msg
@@ -1,0 +1,18 @@
+#
+# Latitude.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Latitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# lat Latitude, -- in 1/10th micro degrees
+# Latitude ::= INTEGER (-900000000..900000001)
+#  -- LSB = 1/10 micro degree
+#  -- Providing a range of plus-minus 90 degrees
+#  -- Convert to degree with factor 0.0000001 when field is used
+int32 latitude
+
+int32 LATITUDE_UNAVAILABLE = 900000001
+int32 LATITUDE_MAX = 900000000
+int32 LATITUDE_MIN = -900000000

--- a/j2735_v2x_msgs/msg/Longitude.msg
+++ b/j2735_v2x_msgs/msg/Longitude.msg
@@ -1,0 +1,18 @@
+#
+# Longitude.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Longitude from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# long Longitude, -- in 1/10th micro degrees
+# Longitude ::= INTEGER (-1799999999..1800000001)
+#  -- LSB = 1/10 micro degree
+#  -- Providing a range of plus-minus 180 degrees
+#  -- Convert to degree with factor 0.0000001 when field is used
+int32 longitude
+
+int32 LONGITUDE_UNAVAILABLE = 1800000001
+int32 LONGITUDE_MAX = 1800000000
+int32 LONGITUDE_MIN = -1799999999

--- a/j2735_v2x_msgs/msg/MotorizedPropelledType.msg
+++ b/j2735_v2x_msgs/msg/MotorizedPropelledType.msg
@@ -1,0 +1,26 @@
+#
+# MotorizedPropelledType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of MotorizedPropelledType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# MotorizedPropelledType ::= ENUMERATED {   
+#    unavailable         (0),
+#    otherTypes          (1), -- any method not listed below
+#    wheelChair          (2),
+#    bicycle             (3),
+#    scooter             (4),
+#    selfBalancingDevice (5), -- such as Segway
+#    ...
+# }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 OTHER_TYPES=1
+uint8 WHEELCHAIR=2
+uint8 BICYCLE=3
+uint8 SCOOTER=4
+uint8 SELF_BALANCING_DEVICE=5

--- a/j2735_v2x_msgs/msg/MsgCount.msg
+++ b/j2735_v2x_msgs/msg/MsgCount.msg
@@ -1,0 +1,12 @@
+#
+# MsgCount.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of MsgCount from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# MsgCount ::= INTEGER (0..127)
+uint8 msg_cnt
+
+uint8 MSG_COUNT_MAX = 127

--- a/j2735_v2x_msgs/msg/NumberOfParticipantsInCluster.msg
+++ b/j2735_v2x_msgs/msg/NumberOfParticipantsInCluster.msg
@@ -1,0 +1,22 @@
+#
+# NumberOfParticipantsInCluster.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of NumberOfParticipantsInCluster from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# NumberOfParticipantsInCluster ::= ENUMERATED { 
+#    unavailable  (0),
+#    small        (1),   -- 2-5
+#    medium       (2),   -- 6-10
+#    large        (3),   -- >10
+#    ...
+#    }
+
+uint8 cluster_size
+
+uint8 UNAVAILABLE=0
+uint8 SMALL=1
+uint8 MEDIUM=2
+uint8 LARGE=3

--- a/j2735_v2x_msgs/msg/PSM.msg
+++ b/j2735_v2x_msgs/msg/PSM.msg
@@ -1,0 +1,95 @@
+#
+# PSM.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Personal Safety Message (PSM) from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# A BIT STRING defining the presence of optional feilds.
+# Compare with bitwise-and
+# if (presence_vector & HAS_PATH_HISTORY) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_PATH_HISTORY
+uint32 presence_vector
+
+uint32 HAS_ACCEL_SET = 1
+uint32 HAS_PATH_HISTORY = 2
+uint32 HAS_PATH_PREDICTION = 4
+uint32 HAS_PROPULSION = 8
+uint32 HAS_USE_STATE = 16
+uint32 HAS_CROSS_REQUEST = 32
+uint32 HAS_CROSS_STATE = 64
+uint32 HAS_CLUSTER_SIZE = 128
+uint32 HAS_CLUSTER_RADIUS = 256
+uint32 HAS_EVENT_RESPONDER_TYPE = 512
+uint32 HAS_ACTIVITY_TYPE = 1024
+uint32 HAS_ACTIVITY_SUB_TYPE = 2048
+uint32 HAS_ASSIST_TYPE = 4096
+uint32 HAS_SIZING = 8192
+uint32 HAS_ATTACHMENT= 16384
+uint32 HAS_ATTACHMENT_RADIUS = 32768
+uint32 HAS_ANIMAL_TYPE = 65536
+uint32 HAS_REGIONAL_EXTENSION = 131072
+
+j2735_v2x_msgs/PersonalDeviceUserType basic_type
+
+j2735_v2x_msgs/DSecond sec_mark
+
+j2735_v2x_msgs/MsgCount msg_cnt
+
+j2735_v2x_msgs/TemporaryID id
+
+j2735_v2x_msgs/Position3D position
+
+j2735_v2x_msgs/PositionalAccuracy accuracy
+
+j2735_v2x_msgs/Velocity speed
+
+j2735_v2x_msgs/Heading heading
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+j2735_v2x_msgs/AccelerationSet4Way accel_set
+
+j2735_v2x_msgs/PathHistory path_history
+
+j2735_v2x_msgs/PathPrediction path_prediction
+
+j2735_v2x_msgs/PropelledInformation propulsion
+
+j2735_v2x_msgs/PersonalDeviceUsageState use_state
+
+j2735_v2x_msgs/PersonalCrossingRequest cross_request
+
+j2735_v2x_msgs/PersonalCrossingInProgress cross_state
+
+j2735_v2x_msgs/NumberOfParticipantsInCluster cluster_size
+
+j2735_v2x_msgs/PersonalClusterRadius cluster_radius
+
+j2735_v2x_msgs/PublicSafetyEventResponderWorkerType event_responder_type
+
+j2735_v2x_msgs/PublicSafetyAndRoadWorkerActivity activity_type
+
+j2735_v2x_msgs/PublicSafetyDirectingTrafficSubType activity_sub_type
+
+j2735_v2x_msgs/PersonalAssistive assist_type
+
+j2735_v2x_msgs/UserSizeAndBehaviour sizing
+
+j2735_v2x_msgs/Attachment attachment
+
+j2735_v2x_msgs/AttachmentRadius attachment_radius
+
+j2735_v2x_msgs/AnimalType animal_type
+
+# TODO Approach to defining regional extensions in ROS has not yet been idenfied. If it is, this field will be updated.
+# regional SEQUENCE (SIZE(1..4)) OF 
+#            j2735_v2x_msgs/RegionalExtension {{REGION.Reg-PersonalSafetyMessage}} OPTIONAL,
+#   ...
+#   }

--- a/j2735_v2x_msgs/msg/PathHistory.msg
+++ b/j2735_v2x_msgs/msg/PathHistory.msg
@@ -1,0 +1,33 @@
+#
+# PathHistory.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PathHistory from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PathHistory ::= SEQUENCE {
+#    initialPosition  FullPositionVector    OPTIONAL,
+#    currGNSSstatus   GNSSstatus            OPTIONAL,   
+#    crumbData  	    PathHistoryPointList,
+#    ...
+#    }
+
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_CURR_GNSS_STATUS) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_CURR_GNSS_STATUS
+uint8 presence_vector
+
+uint8 HAS_CURR_GNSS_STATUS = 1
+uint8 HAS_INITIAL_POSITION = 2
+
+
+####
+# OPTIONAL FIELDS
+# All fields below this section are optional.
+# The presence of a given field can be idenfied by checking the precense_vector
+####
+j2735_v2x_msgs/FullPositionVector initial_position
+j2735_v2x_msgs/GNSSStatus curr_gnss_status

--- a/j2735_v2x_msgs/msg/PathPrediction.msg
+++ b/j2735_v2x_msgs/msg/PathPrediction.msg
@@ -1,0 +1,26 @@
+#
+# PathPrediction.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PathPrediction from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PathPrediction ::= SEQUENCE {
+#    radiusOfCurve RadiusOfCurvature, 
+#                  -- LSB units of 10cm
+#                  -- straight path to use value of 32767
+#    confidence    Confidence, 
+#                  -- LSB units of 0.5 percent
+#    ...  
+#    }
+
+# RadiusOfCurvature ::= INTEGER (-32767..32767)
+#    -- LSB units of 10cm
+#    -- A straight path to use value of 32767
+int16 radius_of_curvature
+
+
+# Confidence ::= INTEGER (0..200)
+#    -- LSB units of 0.5 percent
+uint8 confidence

--- a/j2735_v2x_msgs/msg/PersonalAssistive.msg
+++ b/j2735_v2x_msgs/msg/PersonalAssistive.msg
@@ -1,0 +1,30 @@
+#
+# PersonalAssistive.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalAssistive from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalAssistive::= BIT STRING {
+#    unavailable    (0),
+#    otherType      (1),
+#    vision         (2),
+#    hearing        (3),
+#    movement       (4),
+#    cognition      (5)
+#    } (SIZE (6, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (types & OTHER_TYPE) etc.
+# Create with bitwise-or
+# types = types | OTHER_TYPE
+uint8 types
+
+uint8 UNAVAILABLE = 0
+uint8 OTHER_TYPE = 1
+uint8 VISION = 2
+uint8 HEARING = 4
+uint8 MOVEMENT = 8
+uint8 COGNITION = 16

--- a/j2735_v2x_msgs/msg/PersonalClusterRadius.msg
+++ b/j2735_v2x_msgs/msg/PersonalClusterRadius.msg
@@ -1,0 +1,11 @@
+#
+# PersonalClusterRadius.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalClusterRadius from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalClusterRadius ::= INTEGER (0..100) -- units of meters
+uint8 cluster_radius
+uint8 CLUSTER_RADIUS_MAX = 100

--- a/j2735_v2x_msgs/msg/PersonalCrossingInProgress.msg
+++ b/j2735_v2x_msgs/msg/PersonalCrossingInProgress.msg
@@ -1,0 +1,12 @@
+#
+# PersonalCrossingInProgress.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalCrossingInProgress from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalCrossingInProgress ::= BOOLEAN -- Use:
+#    -- True  = Yes, is in maneuver
+#    -- False = No
+bool cross_state

--- a/j2735_v2x_msgs/msg/PersonalCrossingRequest.msg
+++ b/j2735_v2x_msgs/msg/PersonalCrossingRequest.msg
@@ -1,0 +1,13 @@
+#
+# PersonalCrossingRequest.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalCrossingRequest from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalCrossingRequest ::= BOOLEAN 
+#    -- Use:
+#    -- True  = On  (request crossing)
+#    -- False = Off (no request)
+bool cross_request

--- a/j2735_v2x_msgs/msg/PersonalDeviceUsageState.msg
+++ b/j2735_v2x_msgs/msg/PersonalDeviceUsageState.msg
@@ -1,0 +1,40 @@
+#
+# PersonalDeviceUsageState.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalDeviceUsageState from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PersonalDeviceUsageState ::= BIT STRING {  
+#    unavailable      (0), -- Not specified
+#    other            (1), -- Used for states not defined below
+#    idle             (2), -- Human is not interacting with device  
+#    listeningToAudio (3), -- Any audio source other then calling 
+#    typing           (4), -- Including texting, entering addresses 
+#                          -- and other manual input activity 
+#    calling          (5),   
+#    playingGames     (6),   
+#    reading          (7),   
+#    viewing          (8)  -- Watching dynamic content, including following 
+#                          -- navigation prompts, viewing videos or other 
+#                          -- visual contents that are not static
+#    } (SIZE (9, ...))
+#    -- All bits shall be set to zero when unknown state
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (states & IDLE) etc.
+# Create with bitwise-or
+# states = states | IDLE
+uint16 states
+
+uint16 UNAVAILABLE=0
+uint16 OTHER=1
+uint16 IDLE=2
+uint16 LISTENING_TO_AUDIO=4
+uint16 TYPING=8
+uint16 CALLING=16
+uint16 PLAYING_GAMES=32
+uint16 READING=64
+uint16 VIEWING=128

--- a/j2735_v2x_msgs/msg/PersonalDeviceUserType.msg
+++ b/j2735_v2x_msgs/msg/PersonalDeviceUserType.msg
@@ -1,0 +1,26 @@
+#
+# PersonalDeviceUserType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PersonalDeviceUserType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+
+# PersonalDeviceUserType ::= ENUMERATED { 
+#    unavailable           (0),
+#    aPEDESTRIAN           (1), -- Further details may be provided elsewhere
+#    aPEDALCYCLIST         (2), -- Presumed to be human propelled, 
+#                               -- unless PropelledInformation indicates motorized
+#    aPUBLICSAFETYWORKER   (3),
+#    anANIMAL              (4),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 A_PEDESTRIAN=1
+uint8 A_PEDALCYCLIST=2
+uint8 A_PUBLIC_SAFETY_WORKER=3
+uint8 AN_ANIMAL=4

--- a/j2735_v2x_msgs/msg/PositionConfidence.msg
+++ b/j2735_v2x_msgs/msg/PositionConfidence.msg
@@ -1,0 +1,45 @@
+#
+# PositionConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PositionConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PositionConfidence ::= ENUMERATED {
+#    unavailable (0),  -- B'0000  Not Equipped or unavailable
+#    a500m   (1), -- B'0001  500m  or about 5 * 10 ^ -3 decimal degrees
+#    a200m   (2), -- B'0010  200m  or about 2 * 10 ^ -3 decimal degrees
+#    a100m   (3), -- B'0011  100m  or about 1 * 10 ^ -3 decimal degrees
+#    a50m    (4), -- B'0100  50m   or about 5 * 10 ^ -4 decimal degrees 
+#    a20m    (5), -- B'0101  20m   or about 2 * 10 ^ -4 decimal degrees 
+#    a10m    (6), -- B'0110  10m   or about 1 * 10 ^ -4 decimal degrees 
+#    a5m     (7), -- B'0111  5m    or about 5 * 10 ^ -5 decimal degrees 
+#    a2m     (8), -- B'1000  2m    or about 2 * 10 ^ -5 decimal degrees 
+#    a1m     (9), -- B'1001  1m    or about 1 * 10 ^ -5 decimal degrees 
+#    a50cm  (10), -- B'1010  0.50m or about 5 * 10 ^ -6 decimal degrees 
+#    a20cm  (11), -- B'1011  0.20m or about 2 * 10 ^ -6 decimal degrees 
+#    a10cm  (12), -- B'1100  0.10m or about 1 * 10 ^ -6 decimal degrees 
+#    a5cm   (13), -- B'1101  0.05m or about 5 * 10 ^ -7 decimal degrees 
+#    a2cm   (14), -- B'1110  0.02m or about 2 * 10 ^ -7 decimal degrees 
+#    a1cm   (15)  -- B'1111  0.01m or about 1 * 10 ^ -7 decimal degrees 
+#    } 
+
+uint8 confidence
+
+uint8 UNAVAILABLE=0
+uint8 A500M=1
+uint8 A200M=2
+uint8 A100M=3
+uint8 A50M=4
+uint8 A20M=5
+uint8 A10M=6
+uint8 A5M=7
+uint8 A2M=8
+uint8 A1M=9
+uint8 A50CM=10
+uint8 A20CM=11
+uint8 A10CM=12
+uint8 A5CM=13
+uint8 A2CM=14
+uint8 A1CM=15

--- a/j2735_v2x_msgs/msg/PositionConfidenceSet.msg
+++ b/j2735_v2x_msgs/msg/PositionConfidenceSet.msg
@@ -1,0 +1,16 @@
+#
+# PositionConfidenceSet.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PositionConfidenceSet from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PositionConfidenceSet ::= SEQUENCE {
+#    pos        PositionConfidence, -- for both horizontal directions
+#    elevation  ElevationConfidence 
+#    }
+
+j2735_v2x_msgs/PositionConfidence pos
+
+j2735_v2x_msgs/ElevationConfidence elevation

--- a/j2735_v2x_msgs/msg/PropelledInformation.msg
+++ b/j2735_v2x_msgs/msg/PropelledInformation.msg
@@ -1,0 +1,25 @@
+#
+# PropelledInformation.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PropelledInformation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PropelledInformation ::= CHOICE {
+#    human   HumanPropelledType, -- PersonalDeviceUserType would be a aPEDESTRIAN
+#    animal  AnimalPropelledType,
+#    motor   MotorizedPropelledType,
+#    ...
+# }    
+
+uint8 choice
+
+uint8 CHOICE_HUMAN=0
+uint8 CHOICE_ANIMAL=1
+uint8 CHOICE_MOTOR=2
+
+# Following fields selected by the choice enum
+j2735_v2x_msgs/HumanPropelledType human
+j2735_v2x_msgs/AnimalPropelledType animal
+j2735_v2x_msgs/MotorizedPropelledType motor

--- a/j2735_v2x_msgs/msg/PublicSafetyAndRoadWorkerActivity.msg
+++ b/j2735_v2x_msgs/msg/PublicSafetyAndRoadWorkerActivity.msg
@@ -1,0 +1,52 @@
+#
+# PublicSafetyAndRoadWorkerActivity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PropelledInformation from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyAndRoadWorkerActivity ::= BIT STRING {
+#    unavailable          (0), -- Not specified
+#    workingOnRoad        (1), -- Road workers on foot, in or out of 
+#                              -- a closure, performing activities like: 
+#                              -- construction, land surveying, 
+#                              -- trash removal, or site inspection.
+#    settingUpClosures    (2), -- Road workers on foot performing
+#                              -- activities like: setting up signs, 
+#                              -- placing cones/barrels/pylons, or placing 
+#                              -- flares.  Note: People are in the road 
+#                              -- redirecting traffic, but the closure is 
+#                              -- not complete, so utmost care is required 
+#                              -- to determine the allowed path to take to 
+#                              -- avoid entering the work zone and/or 
+#                              -- harming the workers.
+#    respondingToEvents   (3), -- Public safety or other road workers on
+#                              -- foot performing activities like: treating 
+#                              -- injured people, putting out fires, 
+#                              -- cleaning chemical spills, aiding disabled 
+#                              -- vehicles, criminal investigations, 
+#                              -- or animal control.  Note: These events tend 
+#                              -- to be more dynamic than workingOnRoad
+#    directingTraffic     (4), -- Public safety or other road workers on
+#                              -- foot directing traffic in situations like: 
+#                              -- a traffic signal out of operation, 
+#                              -- a construction or crash site with a short 
+#                              -- term lane closure, a single lane flagging 
+#                              -- operation, or ingress/egress to a special event.
+#    otherActivities      (5)  -- Designated by regional authorities  
+#    } (SIZE (6, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (activities & SETTING_UP_CLOSURES) etc.
+# Create with bitwise-or
+# activities = activities | SETTING_UP_CLOSURES
+uint8 activities
+
+uint8 UNAVAILABLE=0
+uint8 WORKING_ON_ROAD=1
+uint8 SETTING_UP_CLOSURES=2
+uint8 RESPONDING_TO_EVENTS=4
+uint8 DIRECTING_TRAFFIC=8
+uint8 OTHER_ACTIVITIES=16

--- a/j2735_v2x_msgs/msg/PublicSafetyDirectingTrafficSubType.msg
+++ b/j2735_v2x_msgs/msg/PublicSafetyDirectingTrafficSubType.msg
@@ -1,0 +1,48 @@
+#
+# PublicSafetyAndRoadWorkerActivity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyDirectingTrafficSubType ::= BIT STRING {
+#    unavailable                        (0),
+#       -- Default.  
+#       -- to be used if unknown or if the worker type is not otherwise identified
+#    policeAndTrafficOfficers           (1), 
+#       -- Law enforcement officers, including traffic control officers,
+#       -- and adult school crossing guards.
+#    trafficControlPersons              (2), 
+#      -- Road workers with special equipment for directing traffic.
+#    railroadCrossingGuards             (3), 
+#      -- Railroad crossing guards who notify motorists of approaching trains 
+#      -- at locations like private roads or driveways crossing train tracks 
+#      -- and where automated equipment is disabled or not present. 
+#    civilDefenseNationalGuardMilitaryPolice (4),
+#         -- while performing their regular duties or during National
+#      -- or local emergencies
+#    emergencyOrganizationPersonnel     (5),
+#       -- Personnel belonging to emergency response organizations such as
+#       -- fire departments, hospitals, river rescue, or associated with
+#       -- emergency vehicles including ambulances as designated by the 
+#       -- regional authority (relating to designation of emergency vehicles)
+#       -- while performing their duties.
+#    highwayServiceVehiclePersonnel     (6)
+#       -- Associated with tow trucks and road service vehicles.
+#    } (SIZE (7, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (sub_types & POLICE_AND_TRAFFIC_OFFICERS) etc.
+# Create with bitwise-or
+# sub_types = sub_types | POLICE_AND_TRAFFIC_OFFICERS
+uint8 sub_types
+
+uint8 UNAVAILABLE = 0
+uint8 POLICE_AND_TRAFFIC_OFFICERS = 1
+uint8 TRAFFIC_CONTROL_PERSONS = 2
+uint8 RAILROAD_CROSSING_GURADS = 4
+uint8 CIVIL_DEFENSE_NATIONAL_GUARD_MILITARY_POLICE = 8
+uint8 EMERGENCY_ORGANIZATION_PERSONNEL = 16
+uint8 HIGHWAY_SERVICE_VEHICLE_PERSONNEL = 32

--- a/j2735_v2x_msgs/msg/PublicSafetyEventResponderWorkerType.msg
+++ b/j2735_v2x_msgs/msg/PublicSafetyEventResponderWorkerType.msg
@@ -1,0 +1,30 @@
+#
+# PublicSafetyEventResponderWorkerType.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# PublicSafetyEventResponderWorkerType ::= ENUMERATED { 
+#    unavailable               (0),
+#    towOperater               (1),
+#    fireAndEMSWorker          (2),
+#    aDOTWorker                (3),
+#    lawEnforcement            (4),
+#    hazmatResponder           (5), -- also any toxicSubstanceCleanupCrew
+#    animalControlWorker       (6),
+#    otherPersonnel            (7),
+#    ...
+#    }
+
+uint8 type
+
+uint8 UNAVAILABLE=0
+uint8 TOW_OPERATOR=1
+uint8 FIRE_EMS_WORKER=2
+uint8 ADOT_WORKER=3
+uint8 LAW_ENFORCEMENT=4
+uint8 HAZMAT_RESPONDER=5
+uint8 ANIMAL_CONTROL_WORKER=6
+uint8 OTHER_PERSONNEL=7

--- a/j2735_v2x_msgs/msg/SpeedandHeadingandThrottleConfidence.msg
+++ b/j2735_v2x_msgs/msg/SpeedandHeadingandThrottleConfidence.msg
@@ -1,0 +1,17 @@
+#
+# SpeedandHeadingandThrottleConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of SpeedandHeadingandThrottleConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# SpeedandHeadingandThrottleConfidence ::= SEQUENCE {
+#    heading   HeadingConfidence,    
+#    speed     SpeedConfidence,      
+#    throttle  ThrottleConfidence    
+#    }
+
+j2735_v2x_msgs/HeadingConfidence heading
+j2735_v2x_msgs/SpeedConfidence speed
+j2735_v2x_msgs/ThrottleConfidence throttle

--- a/j2735_v2x_msgs/msg/TemporaryID.msg
+++ b/j2735_v2x_msgs/msg/TemporaryID.msg
@@ -1,0 +1,14 @@
+#
+# TemporaryID.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TemporaryID from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TemporaryID ::= OCTET STRING (SIZE(4))
+
+uint8[] id
+
+#TemporaryID will change every 3000 seconds.
+uint16 ID_TIME_MAX = 3000

--- a/j2735_v2x_msgs/msg/ThrottleConfidence.msg
+++ b/j2735_v2x_msgs/msg/ThrottleConfidence.msg
@@ -1,0 +1,21 @@
+#
+# ThrottleConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of ThrottleConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# ThrottleConfidence ::= ENUMERATED {
+#    unavailable     (0), -- B'00  Not Equipped or unavailable
+#    prec10percent   (1), -- B'01  10  percent Confidence level
+#    prec1percent    (2), -- B'10  1   percent Confidence level
+#    prec0-5percent  (3)  -- B'11  0.5 percent Confidence level
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 PREC_10_PERCENT = 1
+uint8 PREC_1_PERCENT = 2
+uint8 PREC_05_PERCENT = 3

--- a/j2735_v2x_msgs/msg/TimeConfidence.msg
+++ b/j2735_v2x_msgs/msg/TimeConfidence.msg
@@ -1,0 +1,96 @@
+#
+# TimeConfidence.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TimeConfidence from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TimeConfidence ::= ENUMERATED {
+#    unavailable              (0), -- Not Equipped or unavailable
+#    time-100-000             (1), -- Better than  100 Seconds
+#    time-050-000             (2), -- Better than  50 Seconds
+#    time-020-000             (3), -- Better than  20 Seconds
+#    time-010-000             (4), -- Better than  10 Seconds
+#    time-002-000             (5), -- Better than  2 Seconds
+#    time-001-000             (6), -- Better than  1 Second
+#    time-000-500             (7), -- Better than  0.5 Seconds
+#    time-000-200             (8), -- Better than  0.2 Seconds
+#    time-000-100             (9), -- Better than  0.1 Seconds
+#    time-000-050            (10), -- Better than  0.05 Seconds
+#    time-000-020            (11), -- Better than  0.02 Seconds
+#    time-000-010            (12), -- Better than  0.01 Seconds
+#    time-000-005            (13), -- Better than  0.005 Seconds
+#    time-000-002            (14), -- Better than  0.002 Seconds
+#    time-000-001            (15), -- Better than  0.001 Seconds
+#                                  -- Better than  one millisecond
+#    time-000-000-5          (16), -- Better than  0.000,5 Seconds
+#    time-000-000-2          (17), -- Better than  0.000,2 Seconds
+#    time-000-000-1          (18), -- Better than  0.000,1 Seconds
+#    time-000-000-05         (19), -- Better than  0.000,05 Seconds
+#    time-000-000-02         (20), -- Better than  0.000,02 Seconds
+#    time-000-000-01         (21), -- Better than  0.000,01 Seconds
+#    time-000-000-005        (22), -- Better than  0.000,005 Seconds
+#    time-000-000-002        (23), -- Better than  0.000,002 Seconds
+#    time-000-000-001        (24), -- Better than  0.000,001 Seconds 
+#                                  -- Better than  one micro second
+#    time-000-000-000-5      (25), -- Better than  0.000,000,5 Seconds
+#    time-000-000-000-2      (26), -- Better than  0.000,000,2 Seconds
+#    time-000-000-000-1      (27), -- Better than  0.000,000,1 Seconds
+#    time-000-000-000-05     (28), -- Better than  0.000,000,05 Seconds
+#    time-000-000-000-02     (29), -- Better than  0.000,000,02 Seconds
+#    time-000-000-000-01     (30), -- Better than  0.000,000,01 Seconds
+#    time-000-000-000-005    (31), -- Better than  0.000,000,005 Seconds
+#    time-000-000-000-002    (32), -- Better than  0.000,000,002 Seconds
+#    time-000-000-000-001    (33), -- Better than  0.000,000,001 Seconds
+#                                  -- Better than  one nano second
+#    time-000-000-000-000-5  (34), -- Better than  0.000,000,000,5 Seconds
+#    time-000-000-000-000-2  (35), -- Better than  0.000,000,000,2 Seconds
+#    time-000-000-000-000-1  (36), -- Better than  0.000,000,000,1 Seconds
+#    time-000-000-000-000-05 (37), -- Better than  0.000,000,000,05 Seconds
+#    time-000-000-000-000-02 (38), -- Better than  0.000,000,000,02 Seconds
+#    time-000-000-000-000-01 (39)  -- Better than  0.000,000,000,01 Seconds 
+#    }
+
+uint8 confidence
+
+uint8 UNAVAILABLE = 0
+uint8 TIME_100_000 = 1
+uint8 TIME_050_000 = 2
+uint8 TIME_020_000 = 3
+uint8 TIME_010_000 = 4
+uint8 TIME_002_000 = 5
+uint8 TIME_001_000 = 6
+uint8 TIME_000_500 = 7
+uint8 TIME_000_200 = 8
+uint8 TIME_000_100 = 9
+uint8 TIME_000_050 = 10
+uint8 TIME_000_020 = 11
+uint8 TIME_000_010 = 12
+uint8 TIME_000_005 = 13
+uint8 TIME_000_002 = 14
+uint8 TIME_000_001 = 15
+uint8 TIME_000_000_5 = 16
+uint8 TIME_000_000_2 = 17
+uint8 TIME_000_000_1 = 18
+uint8 TIME_000_000_05 = 19
+uint8 TIME_000_000_02 = 20
+uint8 TIME_000_000_01 = 21
+uint8 TIME_000_000_005 = 22
+uint8 TIME_000_000_002 = 23
+uint8 TIME_000_000_001 = 24
+uint8 TIME_000_000_000_5 = 25
+uint8 TIME_000_000_000_2 = 26
+uint8 TIME_000_000_000_1 = 27
+uint8 TIME_000_000_000_05 = 28
+uint8 TIME_000_000_000_02 = 29
+uint8 TIME_000_000_000_01 = 30
+uint8 TIME_000_000_000_005 = 31
+uint8 TIME_000_000_000_002 = 32
+uint8 TIME_000_000_000_001 = 33
+uint8 TIME_000_000_000_000_5 = 34
+uint8 TIME_000_000_000_000_2 = 35
+uint8 TIME_000_000_000_000_1 = 36
+uint8 TIME_000_000_000_000_05 = 37
+uint8 TIME_000_000_000_000_02 = 38
+uint8 TIME_000_000_000_000_01 = 39

--- a/j2735_v2x_msgs/msg/TransmissionAndSpeed.msg
+++ b/j2735_v2x_msgs/msg/TransmissionAndSpeed.msg
@@ -1,0 +1,16 @@
+#
+# TransmissionAndSpeed.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of TransmissionAndSpeed from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# TransmissionAndSpeed ::= SEQUENCE {
+#    transmisson   TransmissionState,
+#    speed         Velocity
+#    }
+
+j2735_v2x_msgs/TransmissionState transmission
+
+j2735_v2x_msgs/Velocity speed

--- a/j2735_v2x_msgs/msg/UserSizeAndBehaviour.msg
+++ b/j2735_v2x_msgs/msg/UserSizeAndBehaviour.msg
@@ -1,0 +1,28 @@
+#
+# UserSizeAndBehaviour.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of PublicSafetyDirectingTrafficSubType from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# UserSizeAndBehaviour ::= BIT STRING { 
+#    unavailable                     (0),
+#    smallStature                    (1), -- less than 150 cm high
+#    largeStature                    (2),
+#    erraticMoving                   (3), 
+#    slowMoving                      (4)  -- those who move a bit slowly
+#    } (SIZE (5, ...))
+
+# A BIT STRING defining the presence of optional flags.
+# Compare with bitwise-and
+# if (sizes_and_behaviors & SMALL_STATURE) etc.
+# Create with bitwise-or
+# sizes_and_behaviors = activities | SMALL_STATURE
+uint8 sizes_and_behaviors
+
+uint8 UNAVAILABLE = 0
+uint8 SMALL_STATURE = 1
+uint8 LARGE_STATURE = 2
+uint8 ERRATIC_MOVING = 4
+uint8 SLOW_MOVING = 8

--- a/j2735_v2x_msgs/msg/Velocity.msg
+++ b/j2735_v2x_msgs/msg/Velocity.msg
@@ -1,0 +1,18 @@
+#
+# Velocity.msg
+#
+# J2735 2016 message format.
+#
+# Parsed description of Velocity from the SAE J2735 2016 specification.
+# For further usage details consult the specification.
+#
+# Velocity ::= INTEGER (0..8191) -- Units of 0.02 m/s
+#     -- The value 8191 indicates that 
+#     -- velocity is unavailable
+
+uint16 velocity
+
+uint16 MIN=0
+uint16 MAX=8190
+uint16 UNAVAILABLE=8191
+


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds the J2735 PSM message to both the ROS2 and ROS1 messages packages. As with the other J2735 messages a simplified SI units version is added to carma_v2x_msgs and cav_msgs. The only thing which wasn't attempted to SI units was the DDateTime.msg which is a complex optional structure that would have been difficult to represent as a single timestamp. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1672
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Needed for PSM support to be added in cooperative perception demonstration
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Build testing in ROS1 and ROS2
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.