### PR TITLE
Update carma messenger encoder/decoder for mobility response additions

### DIFF
--- a/carma_v2x_msgs/msg/MobilityPlanType.msg
+++ b/carma_v2x_msgs/msg/MobilityPlanType.msg
@@ -1,0 +1,23 @@
+# MobilityPlanType.msg
+#
+#
+
+# Variable which can be used to store a specific plan type value.
+uint8 choice
+
+# enumeration values for mobility plan type:
+
+uint8       UNKNOWN=0 
+uint8       CHANGINGLANESTOTHELEFT=1 
+uint8       CHANGINGLANESTOTHERIGHT=2 
+uint8       JOINPLATOONATREAR=3
+uint8       PLATOONFOLLOWERJOIN=4
+uint8       JOINPLATOONFROMFRONT=5
+uint8       PLATOONFRONTJOIN=6
+uint8       CUTINFROMSIDE=7
+uint8       PLATOONCUTINJOIN=8
+uint8       STOPCREATEGAP=9
+uint8       CUTINFRONTDONE=10
+uint8       CUTINMIDORREARDONE=11
+uint8       PLATOONDEPARTURE=12
+uint8       DELETEMEMBER=13

--- a/carma_v2x_msgs/msg/MobilityReason.msg
+++ b/carma_v2x_msgs/msg/MobilityReason.msg
@@ -1,0 +1,18 @@
+# MobilityReason.msg
+#
+#
+
+# Variable which can be used to store a specific reason value.
+uint8 choice
+
+# enumeration values for mobility reason:
+
+uint8       UNKNOWN=0 
+uint8       ACCEPTED=1 
+uint8       SAFETYVIOLATION=2 
+uint8       INSUFFICIENTTIME=3
+uint8       PLANCONFLICT=4
+uint8       OTHERWISEENGAGED=5
+uint8       INSUFFICIENTURGENCY=6
+uint8       PLANUNCLEAR=7
+uint8       OTHER=8

--- a/carma_v2x_msgs/msg/MobilityRepeat.msg
+++ b/carma_v2x_msgs/msg/MobilityRepeat.msg
@@ -1,0 +1,12 @@
+# MobilityRepeat.msg
+#
+#
+
+# Variable which can be used to store a specific repeat value.
+uint8 choice
+
+# enumeration values for mobility repeat:
+
+uint8       UNKNOWN=0 
+uint8       REQUESTAGAIN=1 
+uint8       NEVERREQUESTAGAIN=2 

--- a/carma_v2x_msgs/msg/MobilityResponse.msg
+++ b/carma_v2x_msgs/msg/MobilityResponse.msg
@@ -4,10 +4,19 @@
 # recevied a MobilityRequest from that CAV and decide to involve in that plan
 
 # standard header for all mobility messages
-carma_v2x_msgs/MobilityHeader  m_header
+carma_v2x_msgs/MobilityHeader   m_header
 
 # urgency of the current plan from 0 to 1000
-uint16                   urgency
+uint16                          urgency
 
 # the content of this response
-bool                     is_accepted
+bool                            is_accepted
+
+# type of the proposal being suggested to neighbors
+carma_v2x_msgs/MobilityPlanType plan_type
+
+# 
+carma_v2x_msgs/MobilityReason   reason         # OPTIONAL
+
+# Whether or not to repeat the MobilityRequest
+carma_v2x_msgs/MobilityRepeat   repeat         # OPTIONAL

--- a/cav_msgs/msg/MobilityPlanType.msg
+++ b/cav_msgs/msg/MobilityPlanType.msg
@@ -1,0 +1,23 @@
+# MobilityPlanType.msg
+#
+#
+
+# Variable which can be used to store a specific plan type value.
+uint8 type
+
+# enumeration values for mobility plan type:
+
+uint8       UNKNOWN=0 
+uint8       CHANGINGLANESTOTHELEFT=1 
+uint8       CHANGINGLANESTOTHERIGHT=2 
+uint8       JOINPLATOONATREAR=3
+uint8       PLATOONFOLLOWERJOIN=4
+uint8       JOINPLATOONFROMFRONT=5
+uint8       PLATOONFRONTJOIN=6
+uint8       CUTINFROMSIDE=7
+uint8       PLATOONCUTINJOIN=8
+uint8       STOPCREATEGAP=9
+uint8       CUTINFRONTDONE=10
+uint8       CUTINMIDORREARDONE=11
+uint8       PLATOONDEPARTURE=12
+uint8       DELETEMEMBER=13

--- a/cav_msgs/msg/MobilityReason.msg
+++ b/cav_msgs/msg/MobilityReason.msg
@@ -1,0 +1,18 @@
+# MobilityReason.msg
+#
+#
+
+# Variable which can be used to store a specific reason value.
+uint8 reason
+
+# enumeration values for mobility reason:
+
+uint8       UNKNOWN=0 
+uint8       ACCEPTED=1 
+uint8       SAFETYVIOLATION=2 
+uint8       INSUFFICIENTTIME=3
+uint8       PLANCONFLICT=4
+uint8       OTHERWISEENGAGED=5
+uint8       INSUFFICIENTURGENCY=6
+uint8       PLANUNCLEAR=7
+uint8       OTHER=8

--- a/cav_msgs/msg/MobilityRepeat.msg
+++ b/cav_msgs/msg/MobilityRepeat.msg
@@ -1,0 +1,12 @@
+# MobilityRepeat.msg
+#
+#
+
+# Variable which can be used to store a specific repeat value.
+uint8 repeat
+
+# enumeration values for mobility repeat:
+
+uint8       UNKNOWN=0 
+uint8       REQUESTAGAIN=1 
+uint8       NEVERREQUESTAGAIN=2 

--- a/cav_msgs/msg/MobilityResponse.msg
+++ b/cav_msgs/msg/MobilityResponse.msg
@@ -4,10 +4,19 @@
 # recevied a MobilityRequest from that CAV and decide to involve in that plan
 
 # standard header for all mobility messages
-cav_msgs/MobilityHeader  m_header
+cav_msgs/MobilityHeader   m_header
 
 # urgency of the current plan from 0 to 1000
-uint16                   urgency
+uint16                    urgency
 
 # the content of this response
-bool                     is_accepted
+bool                      is_accepted
+
+# type of the proposal being suggested to neighbors
+cav_msgs/MobilityPlanType planType
+
+# 
+cav_msgs/MobilityReason   reason         # OPTIONAL
+
+# Whether or not to repeat the MobilityRequest
+cav_msgs/MobilityRepeat   repeat         # OPTIONAL


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
The mobility message in carma_v2x_msgs and cav_msgs is missing three fields: plantype, reason, and repeatability. These messages should be created, added to the carma-messenger mobility message encoder/decoder, and unit tested. Related to [CAR-5343](https://usdot-carma.atlassian.net/browse/CAR-5343)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/1769

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The unit tests in cpp_message for the mobility message response have been updated to use these three fields. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.