### PR TITLE
added EVR message

### DIFF
--- a/carma_v2x_msgs/msg/EmergencyVehicleResponse.msg
+++ b/carma_v2x_msgs/msg/EmergencyVehicleResponse.msg
@@ -1,0 +1,15 @@
+# EmergencyVehicleResponse.msg
+
+# This message is used to respond to an emegency vehicle, 
+#   usually to let them know that this vehicle cannot make a lane change to get out of the way
+
+# standard header for all mobility messages
+carma_v2x_msgs/MobilityHeader m_header
+
+# False if the vehicle can not get out of the way
+bool can_change_lanes
+
+# OPTIONAL text reason to no be able to get out of the way
+# The maximum length is 128
+# example: "CMV is unable to change lanes for <insert-supported-reason-here>"
+string reason

--- a/carma_v2x_msgs/msg/EmergencyVehicleResponse.msg
+++ b/carma_v2x_msgs/msg/EmergencyVehicleResponse.msg
@@ -6,10 +6,10 @@
 # standard header for all mobility messages
 carma_v2x_msgs/MobilityHeader m_header
 
-# False if the vehicle can not get out of the way
+# False if the host vehicle can not get out of the way
 bool can_change_lanes
 
-# OPTIONAL text reason to no be able to get out of the way
+# OPTIONAL text reason for why the host vehicle is unable to get out of the way
 # The maximum length is 128
 # example: "CMV is unable to change lanes for <insert-supported-reason-here>"
 string reason

--- a/cav_msgs/msg/EmergencyVehicleResponse.msg
+++ b/cav_msgs/msg/EmergencyVehicleResponse.msg
@@ -6,10 +6,10 @@
 # standard header for all mobility messages
 cav_msgs/MobilityHeader m_header
 
-# False if the vehicle can not get out of the way
+# False if the host vehicle can not get out of the way
 bool can_change_lanes
 
-# OPTIONAL text reason to no be able to get out of the way
+# OPTIONAL text reason for why the host vehicle is unable to get out of the way
 # The maximum length is 128
 # example: "CMV is unable to change lanes for <insert-supported-reason-here>"
 string reason

--- a/cav_msgs/msg/EmergencyVehicleResponse.msg
+++ b/cav_msgs/msg/EmergencyVehicleResponse.msg
@@ -1,0 +1,15 @@
+# EmergencyVehicleResponse.msg
+
+# This message is used to respond to an emegency vehicle, 
+#   usually to let them know that this vehicle cannot make a lane change to get out of the way
+
+# standard header for all mobility messages
+cav_msgs/MobilityHeader m_header
+
+# False if the vehicle can not get out of the way
+bool can_change_lanes
+
+# OPTIONAL text reason to no be able to get out of the way
+# The maximum length is 128
+# example: "CMV is unable to change lanes for <insert-supported-reason-here>"
+string reason


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added the EmergencyVehicleResponse message to cav_msgs and carma_v2x_msgs, paralleling the MobilityOperation message. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/CF-414, and https://github.com/usdot-fhwa-stol/carma-platform/issues/1964

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all existing cpp_message unit tests, and they all passed. No way to actually test the message itself as of yet. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.