### PR TITLE
Fixes for nested BSM Part II messages

### DIFF
--- a/carma_v2x_msgs/msg/ObstacleDetection.msg
+++ b/carma_v2x_msgs/msg/ObstacleDetection.msg
@@ -28,9 +28,9 @@ uint16 HAS_DESCRIPTION = 1
 uint16 HAS_LOCATION_DETAILS = 2
 uint16 HAS_VERT_EVENT = 4
 
-j2735_v2x_msgs/ObstacleDistance ob_dist
+carma_v2x_msgs/ObstacleDistance ob_dist
 
-j2735_v2x_msgs/ObstacleDirection ob_direct
+carma_v2x_msgs/ObstacleDirection ob_direct
 
 j2735_v2x_msgs/DDateTime date_time
 

--- a/carma_v2x_msgs/msg/VehicleData.msg
+++ b/carma_v2x_msgs/msg/VehicleData.msg
@@ -26,10 +26,10 @@ uint16 HAS_MASS = 4
 uint16 HAS_TRAILER_WEIGHT = 8
 
 
-j2735_v2x_msgs/VehicleHeight height
+carma_v2x_msgs/VehicleHeight height
 
-j2735_v2x_msgs/BumperHeights bumpers
+carma_v2x_msgs/BumperHeights bumpers
 
-j2735_v2x_msgs/VehicleMass mass
+carma_v2x_msgs/VehicleMass mass
 
 carma_v2x_msgs/TrailerWeight trailer_weight

--- a/carma_v2x_msgs/msg/VehicleMass.msg
+++ b/carma_v2x_msgs/msg/VehicleMass.msg
@@ -1,0 +1,23 @@
+#
+# VehicleMass.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+
+# VehicleMass ::= INTEGER (0..255)
+#     -- Values 000 to 080 in steps of 50kg
+#     -- Values 081 to 200 in steps of 500kg
+#     -- Values 201 to 253 in steps of 2000kg
+#     -- The Value 254 shall be used for weights above 170000 kg
+#     -- The Value 255 shall be used when the value is unknown or unavailable
+#     -- Encoded such that the values:
+#     --  81 represents   4500 kg
+#     -- 181 represents  54500 kg
+#     -- 253 represents 170000 kg
+uint32 vehicle_mass
+
+uint32 MASS_MIN=0
+uint32 MASS_MAX=170000
+
+# If true the vehicle mass is unset
+bool unavailable

--- a/cav_msgs/msg/ObstacleDetection.msg
+++ b/cav_msgs/msg/ObstacleDetection.msg
@@ -28,9 +28,9 @@ uint16 HAS_DESCRIPTION = 1
 uint16 HAS_LOCATION_DETAILS = 2
 uint16 HAS_VERT_EVENT = 4
 
-j2735_msgs/ObstacleDistance ob_dist
+cav_msgs/ObstacleDistance ob_dist
 
-j2735_msgs/ObstacleDirection ob_direct
+cav_msgs/ObstacleDirection ob_direct
 
 j2735_msgs/DDateTime date_time
 

--- a/cav_msgs/msg/VehicleData.msg
+++ b/cav_msgs/msg/VehicleData.msg
@@ -26,10 +26,10 @@ uint16 HAS_MASS = 4
 uint16 HAS_TRAILER_WEIGHT = 8
 
 
-j2735_msgs/VehicleHeight height
+cav_msgs/VehicleHeight height
 
-j2735_msgs/BumperHeights bumpers
+cav_msgs/BumperHeights bumpers
 
-j2735_msgs/VehicleMass mass
+cav_msgs/VehicleMass mass
 
 cav_msgs/TrailerWeight trailer_weight

--- a/cav_msgs/msg/VehicleMass.msg
+++ b/cav_msgs/msg/VehicleMass.msg
@@ -1,0 +1,23 @@
+#
+# VehicleMass.msg
+#
+# Modified J2735 2016 message format, adjusted to use base SI units (m,s, etc) in most case.
+#
+
+# VehicleMass ::= INTEGER (0..255)
+#     -- Values 000 to 080 in steps of 50kg
+#     -- Values 081 to 200 in steps of 500kg
+#     -- Values 201 to 253 in steps of 2000kg
+#     -- The Value 254 shall be used for weights above 170000 kg
+#     -- The Value 255 shall be used when the value is unknown or unavailable
+#     -- Encoded such that the values:
+#     --  81 represents   4500 kg
+#     -- 181 represents  54500 kg
+#     -- 253 represents 170000 kg
+uint32 vehicle_mass
+
+uint32 MASS_MIN=0
+uint32 MASS_MAX=170000
+
+# If true the vehicle mass is unset
+bool unavailable

--- a/j2735_msgs/msg/AmbientAirPressure.msg
+++ b/j2735_msgs/msg/AmbientAirPressure.msg
@@ -11,3 +11,4 @@ uint8 pressure
 
 uint8 PRESSURE_MIN = 0
 uint8 PRESSURE_MAX = 255
+uint8 PRESSURE_UNAVAILABLE = 0

--- a/j2735_msgs/msg/BumperHeight.msg
+++ b/j2735_msgs/msg/BumperHeight.msg
@@ -7,3 +7,6 @@
 # BumperHeight ::= INTEGER (0..127) 
 #    -- in units of 0.01 meters from ground surface.
 uint8 bumper_height
+
+uint8 BUMPER_HEIGHT_MIN=0
+uint8 BUMPER_HEIGHT_MAX=127

--- a/j2735_msgs/msg/CoefficientOfFriction.msg
+++ b/j2735_msgs/msg/CoefficientOfFriction.msg
@@ -9,4 +9,6 @@
 #    -- and  50 = 1.00 micro, in steps of 0.02
 uint8 coefficient
 
+uint8 COEFFICIENT_MIN=0
 uint8 COEFFICIENT_MAX=50
+uint8 COEFFICIENT_UNAVAILABLE=0

--- a/j2735_msgs/msg/DisabledVehicle.msg
+++ b/j2735_msgs/msg/DisabledVehicle.msg
@@ -33,5 +33,7 @@ uint16 presence_vector
 uint16 HAS_LOCATION_DETAILS = 1
 
 j2735_msgs/ITIScodes status_details
+uint16 STATUS_DETAILS_MIN = 532
+uint16 STATUS_DETAILS_MAX = 541
 
 j2735_msgs/ITISGenericLocations location_details

--- a/j2735_msgs/msg/EventDescription.msg
+++ b/j2735_msgs/msg/EventDescription.msg
@@ -40,12 +40,9 @@ uint16 presence_vector
 uint16 HAS_PRIORITY = 1
 uint16 HAS_HEADING = 2
 uint16 HAS_EXTENT = 4
+uint16 HAS_DESCRIPTION = 8
 
 j2735_msgs/ITIScodes type_event
-
-j2735_msgs/ITIScodes[] description
-uint8 DESCRIPTION_SIZE_MIN = 1
-uint8 DESCRIPTION_SIZE_MAX = 8
 
 ####
 # OPTIONAL FIELDS
@@ -58,5 +55,9 @@ j2735_msgs/Priority priority
 j2735_msgs/HeadingSlice heading
 
 j2735_msgs/Extent extent
+
+j2735_msgs/ITIScodes[] description
+uint8 DESCRIPTION_SIZE_MIN = 1
+uint8 DESCRIPTION_SIZE_MAX = 8
 
 # regional #TODO: RegionalExtensions are not yet supported for this message type

--- a/j2735_msgs/msg/NodeXY24b.msg
+++ b/j2735_msgs/msg/NodeXY24b.msg
@@ -20,5 +20,9 @@
 # reference, non-vehicle centric coordinate frames of reference, offset is positive to the East (X) and to the North (Y)
 # directions. The most negative value shall be used to indicate an unknown value.
 
-float32 x
-float32 y
+int16 x
+int16 y
+
+int16 UNKNOWN=-2048
+int16 MIN=-2047
+int16 MAX=2047

--- a/j2735_msgs/msg/ObstacleDetection.msg
+++ b/j2735_msgs/msg/ObstacleDetection.msg
@@ -41,6 +41,8 @@ j2735_msgs/DDateTime date_time
 ####
 
 j2735_msgs/ITIScodes description
+uint16 DESCRIPTION_MIN = 523
+uint16 DESCRIPTION_MAX = 541
 
 j2735_msgs/ITISGenericLocations location_details
 

--- a/j2735_msgs/msg/Priority.msg
+++ b/j2735_msgs/msg/Priority.msg
@@ -6,4 +6,4 @@
 
 # Priority ::= OCTET STRING (SIZE(1))
 #  -- Follow J2735 2016 definition notes on setting these bits
-uint8[] priority
+uint8[1] priority

--- a/j2735_msgs/msg/VehicleClassification.msg
+++ b/j2735_msgs/msg/VehicleClassification.msg
@@ -28,27 +28,40 @@
 #    ...
 #    }
 
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_KEY_TYPE) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_KEY_TYPE
+uint16 presence_vector
+
+uint16 HAS_KEY_TYPE = 1
+uint16 HAS_ROLE = 2
+uint16 HAS_ISO = 4
+uint16 HAS_HPMS_TYPE = 8
+uint16 HAS_VEHICLE_TYPE = 16
+uint16 HAS_RESPONSE_EQUIP = 32
+uint16 HAS_RESPONDER_TYPE = 64
+uint16 HAS_FUEL_TYPE = 128
+
 j2735_msgs/BasicVehicleClass key_type
-bool key_type_exists
 
 j2735_msgs/BasicVehicleRole role
-bool role_exists
 
 # Iso3833VehicleType ::= INTEGER (0..100) 
 # Refer to ISO3833 for valid values
 uint8 iso3833
-bool iso3883_exists
+uint8 ISO3833_MIN=0
+uint8 ISO3833_MAX=100
+
+j2735_msgs/VehicleType hpms_type
 
 j2735_msgs/ITISVehicleGroupAffected vehicle_type 
-bool vehicle_type_exists 
 
 j2735_msgs/ITISIncidentResponseEquipment response_equip
-bool response_equip_exists
 
 j2735_msgs/ITISResponderGroupAffected responder_type
-bool response_type_exists
 
 j2735_msgs/FuelType fuel_type
-bool fuel_type_exists
 
 # regional #TODO: RegionalExtensions are not yet supported for this message type

--- a/j2735_msgs/msg/VehicleType.msg
+++ b/j2735_msgs/msg/VehicleType.msg
@@ -1,0 +1,44 @@
+#
+# VehicleType.msg
+#
+# J2735 2016 message format.
+#
+
+# VehicleType ::= ENUMERATED {
+#    none                 (0),  -- Not Equipped, Not known or unavailable
+#    unknown              (1),  -- Does not fit any other category    
+#    special              (2),  -- Special use    
+#    moto                 (3),  -- Motorcycle    
+#    car                  (4),  -- Passenger car    
+#    carOther             (5),  -- Four tire single units    
+#    bus                  (6),  -- Buses    
+#    axleCnt2             (7),  -- Two axle, six tire single units    
+#    axleCnt3             (8),  -- Three axle, single units    
+#    axleCnt4             (9),  -- Four or more axle, single unit    
+#    axleCnt4Trailer      (10), -- Four or less axle, single trailer    
+#    axleCnt5Trailer      (11), -- Five or less axle, single trailer    
+#    axleCnt6Trailer      (12), -- Six or more axle, single trailer    
+#    axleCnt5MultiTrailer (13), -- Five or less axle, multi-trailer    
+#    axleCnt6MultiTrailer (14), -- Six axle, multi-trailer    
+#    axleCnt7MultiTrailer (15),  -- Seven or more axle, multi-trailer    
+#    ...  
+#    } 
+
+uint8 vehicle_type
+
+uint8 NONE=0
+uint8 UNKNOWN=1
+uint8 SPECIAL=2
+uint8 MOTO=3
+uint8 CAR=4
+uint8 CAR_OTHER=5
+uint8 BUS=6
+uint8 AXLE_CNT_2=7
+uint8 AXLE_CNT_3=8
+uint8 AXLE_CNT_4=9
+uint8 AXLE_CNT_4_TRAILER=10
+uint8 AXLE_CNT_5_TRAILER=11
+uint8 AXLE_CNT_6_TRAILER=12
+uint8 AXLE_CNT_5_MULTI_TRAILER=13
+uint8 AXLE_CNT_6_MULTI_TRAILER=14
+uint8 AXLE_CNT_7_MULTI_TRAILER=15

--- a/j2735_v2x_msgs/msg/AmbientAirPressure.msg
+++ b/j2735_v2x_msgs/msg/AmbientAirPressure.msg
@@ -11,3 +11,4 @@ uint8 pressure
 
 uint8 PRESSURE_MIN = 0
 uint8 PRESSURE_MAX = 255
+uint8 PRESSURE_UNAVAILABLE = 0

--- a/j2735_v2x_msgs/msg/BumperHeight.msg
+++ b/j2735_v2x_msgs/msg/BumperHeight.msg
@@ -7,3 +7,6 @@
 # BumperHeight ::= INTEGER (0..127) 
 #    -- in units of 0.01 meters from ground surface.
 uint8 bumper_height
+
+uint8 BUMPER_HEIGHT_MIN=0
+uint8 BUMPER_HEIGHT_MAX=127

--- a/j2735_v2x_msgs/msg/CoefficientOfFriction.msg
+++ b/j2735_v2x_msgs/msg/CoefficientOfFriction.msg
@@ -9,4 +9,6 @@
 #    -- and  50 = 1.00 micro, in steps of 0.02
 uint8 coefficient
 
+uint8 COEFFICIENT_MIN=0
 uint8 COEFFICIENT_MAX=50
+uint8 COEFFICIENT_UNAVAILABLE=0

--- a/j2735_v2x_msgs/msg/DisabledVehicle.msg
+++ b/j2735_v2x_msgs/msg/DisabledVehicle.msg
@@ -33,5 +33,7 @@ uint16 presence_vector
 uint16 HAS_LOCATION_DETAILS = 1
 
 j2735_v2x_msgs/ITIScodes status_details
+uint16 STATUS_DETAILS_MIN = 532
+uint16 STATUS_DETAILS_MAX = 541
 
 j2735_v2x_msgs/ITISGenericLocations location_details

--- a/j2735_v2x_msgs/msg/EventDescription.msg
+++ b/j2735_v2x_msgs/msg/EventDescription.msg
@@ -40,12 +40,9 @@ uint16 presence_vector
 uint16 HAS_PRIORITY = 1
 uint16 HAS_HEADING = 2
 uint16 HAS_EXTENT = 4
+uint16 HAS_DESCRIPTION = 8
 
 j2735_v2x_msgs/ITIScodes type_event
-
-j2735_v2x_msgs/ITIScodes[] description
-uint8 DESCRIPTION_SIZE_MIN = 1
-uint8 DESCRIPTION_SIZE_MAX = 8
 
 ####
 # OPTIONAL FIELDS
@@ -58,5 +55,9 @@ j2735_v2x_msgs/Priority priority
 j2735_v2x_msgs/HeadingSlice heading
 
 j2735_v2x_msgs/Extent extent
+
+j2735_v2x_msgs/ITIScodes[] description
+uint8 DESCRIPTION_SIZE_MIN = 1
+uint8 DESCRIPTION_SIZE_MAX = 8
 
 # regional #TODO: RegionalExtensions are not yet supported for this message type

--- a/j2735_v2x_msgs/msg/NodeXY24b.msg
+++ b/j2735_v2x_msgs/msg/NodeXY24b.msg
@@ -3,9 +3,6 @@
 #
 # J2735 2016 message format.
 #
-# @author Mae Fromm
-# @version 0.1
-#
 # A 24-bit node type with offset values from the last point in X and Y.
 #
 # Node-XY-24b ::= SEQUENCE {
@@ -20,5 +17,9 @@
 # reference, non-vehicle centric coordinate frames of reference, offset is positive to the East (X) and to the North (Y)
 # directions. The most negative value shall be used to indicate an unknown value.
 
-float32 x
-float32 y
+int16 x
+int16 y
+
+int16 UNKNOWN=-2048
+int16 MIN=-2047
+int16 MAX=2047

--- a/j2735_v2x_msgs/msg/ObstacleDetection.msg
+++ b/j2735_v2x_msgs/msg/ObstacleDetection.msg
@@ -41,6 +41,8 @@ j2735_v2x_msgs/DDateTime date_time
 ####
 
 j2735_v2x_msgs/ITIScodes description
+uint16 DESCRIPTION_MIN = 523
+uint16 DESCRIPTION_MAX = 541
 
 j2735_v2x_msgs/ITISGenericLocations location_details
 

--- a/j2735_v2x_msgs/msg/Priority.msg
+++ b/j2735_v2x_msgs/msg/Priority.msg
@@ -6,4 +6,4 @@
 
 # Priority ::= OCTET STRING (SIZE(1))
 #  -- Follow J2735 2016 definition notes on setting these bits
-uint8[] priority
+uint8[1] priority

--- a/j2735_v2x_msgs/msg/VehicleClassification.msg
+++ b/j2735_v2x_msgs/msg/VehicleClassification.msg
@@ -28,27 +28,40 @@
 #    ...
 #    }
 
+# A BIT STRING defining the presence of optional fields.
+# Compare with bitwise-and
+# if (presence_vector & HAS_KEY_TYPE) etc.
+# Create with bitwise-or
+# presence_vector = presence_vector | HAS_KEY_TYPE
+uint16 presence_vector
+
+uint16 HAS_KEY_TYPE = 1
+uint16 HAS_ROLE = 2
+uint16 HAS_ISO = 4
+uint16 HAS_HPMS_TYPE = 8
+uint16 HAS_VEHICLE_TYPE = 16
+uint16 HAS_RESPONSE_EQUIP = 32
+uint16 HAS_RESPONDER_TYPE = 64
+uint16 HAS_FUEL_TYPE = 128
+
 j2735_v2x_msgs/BasicVehicleClass key_type
-bool key_type_exists
 
 j2735_v2x_msgs/BasicVehicleRole role
-bool role_exists
 
 # Iso3833VehicleType ::= INTEGER (0..100) 
 # Refer to ISO3833 for valid values
 uint8 iso3833
-bool iso3883_exists
+uint8 ISO3833_MIN=0
+uint8 ISO3833_MAX=100
+
+j2735_v2x_msgs/VehicleType hpms_type
 
 j2735_v2x_msgs/ITISVehicleGroupAffected vehicle_type 
-bool vehicle_type_exists 
 
 j2735_v2x_msgs/ITISIncidentResponseEquipment response_equip
-bool response_equip_exists
 
 j2735_v2x_msgs/ITISResponderGroupAffected responder_type
-bool response_type_exists
 
 j2735_v2x_msgs/FuelType fuel_type
-bool fuel_type_exists
 
 # regional #TODO: RegionalExtensions are not yet supported for this message type

--- a/j2735_v2x_msgs/msg/VehicleType.msg
+++ b/j2735_v2x_msgs/msg/VehicleType.msg
@@ -1,0 +1,44 @@
+#
+# VehicleType.msg
+#
+# J2735 2016 message format.
+#
+
+# VehicleType ::= ENUMERATED {
+#    none                 (0),  -- Not Equipped, Not known or unavailable
+#    unknown              (1),  -- Does not fit any other category    
+#    special              (2),  -- Special use    
+#    moto                 (3),  -- Motorcycle    
+#    car                  (4),  -- Passenger car    
+#    carOther             (5),  -- Four tire single units    
+#    bus                  (6),  -- Buses    
+#    axleCnt2             (7),  -- Two axle, six tire single units    
+#    axleCnt3             (8),  -- Three axle, single units    
+#    axleCnt4             (9),  -- Four or more axle, single unit    
+#    axleCnt4Trailer      (10), -- Four or less axle, single trailer    
+#    axleCnt5Trailer      (11), -- Five or less axle, single trailer    
+#    axleCnt6Trailer      (12), -- Six or more axle, single trailer    
+#    axleCnt5MultiTrailer (13), -- Five or less axle, multi-trailer    
+#    axleCnt6MultiTrailer (14), -- Six axle, multi-trailer    
+#    axleCnt7MultiTrailer (15),  -- Seven or more axle, multi-trailer    
+#    ...  
+#    } 
+
+uint8 vehicle_type
+
+uint8 NONE=0
+uint8 UNKNOWN=1
+uint8 SPECIAL=2
+uint8 MOTO=3
+uint8 CAR=4
+uint8 CAR_OTHER=5
+uint8 BUS=6
+uint8 AXLE_CNT_2=7
+uint8 AXLE_CNT_3=8
+uint8 AXLE_CNT_4=9
+uint8 AXLE_CNT_4_TRAILER=10
+uint8 AXLE_CNT_5_TRAILER=11
+uint8 AXLE_CNT_6_TRAILER=12
+uint8 AXLE_CNT_5_MULTI_TRAILER=13
+uint8 AXLE_CNT_6_MULTI_TRAILER=14
+uint8 AXLE_CNT_7_MULTI_TRAILER=15


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR contains minor fixes to nested BSM Part II Content messages based on findings during CARMA Messenger PR #168 [Click Here](https://github.com/usdot-fhwa-stol/carma-messenger/pull/168)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
These changes enable improved maximum/minimum value checks within j2735_convertor and also fix incorrect message field types for several messages.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested as part of related CARMA Messenger PR (linked above) and full carma-msgs image builds with these changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.