### PR TITLE
Fix ElevationConfidence constant in SDSM msgs

### DIFF
--- a/carma_v2x_msgs/msg/SensorDataSharingMessage.msg
+++ b/carma_v2x_msgs/msg/SensorDataSharingMessage.msg
@@ -40,11 +40,11 @@ carma_v2x_msgs/DetectedObjectList objects
 
 # A BIT STRING defining the presence of optional fields.
 # Compare with bitwise-and
-# if (presence_vector & HAS_REF_POS_XY_CONF) etc.
+# if (presence_vector & HAS_REF_POS_EL_CONF) etc.
 # Create with bitwise-or
-# presence_vector = presence_vector | HAS_REF_POS_XY_CONF
+# presence_vector = presence_vector | HAS_REF_POS_EL_CONF
 uint8 presence_vector
 
-uint8 HAS_REF_POS_XY_CONF = 1
+uint8 HAS_REF_POS_EL_CONF = 1
 
 j2735_v2x_msgs/ElevationConfidence ref_pos_el_conf

--- a/cav_msgs/msg/SensorDataSharingMessage.msg
+++ b/cav_msgs/msg/SensorDataSharingMessage.msg
@@ -40,11 +40,11 @@ cav_msgs/DetectedObjectList objects
 
 # A BIT STRING defining the presence of optional fields.
 # Compare with bitwise-and
-# if (presence_vector & HAS_REF_POS_XY_CONF) etc.
+# if (presence_vector & HAS_REF_POS_EL_CONF) etc.
 # Create with bitwise-or
-# presence_vector = presence_vector | HAS_REF_POS_XY_CONF
+# presence_vector = presence_vector | HAS_REF_POS_EL_CONF
 uint8 presence_vector
 
-uint8 HAS_REF_POS_XY_CONF = 1
+uint8 HAS_REF_POS_EL_CONF = 1
 
 j2735_msgs/ElevationConfidence ref_pos_el_conf

--- a/j3224_msgs/msg/SensorDataSharingMessage.msg
+++ b/j3224_msgs/msg/SensorDataSharingMessage.msg
@@ -37,11 +37,11 @@ j3224_msgs/DetectedObjectList objects
 
 # A BIT STRING defining the presence of optional fields.
 # Compare with bitwise-and
-# if (presence_vector & HAS_REF_POS_XY_CONF) etc.
+# if (presence_vector & HAS_REF_POS_EL_CONF) etc.
 # Create with bitwise-or
-# presence_vector = presence_vector | HAS_REF_POS_XY_CONF
+# presence_vector = presence_vector | HAS_REF_POS_EL_CONF
 uint8 presence_vector
 
-uint8 HAS_REF_POS_XY_CONF = 1
+uint8 HAS_REF_POS_EL_CONF = 1
 
 j2735_msgs/ElevationConfidence ref_pos_el_conf

--- a/j3224_v2x_msgs/msg/SensorDataSharingMessage.msg
+++ b/j3224_v2x_msgs/msg/SensorDataSharingMessage.msg
@@ -37,11 +37,11 @@ j3224_v2x_msgs/DetectedObjectList objects
 
 # A BIT STRING defining the presence of optional fields.
 # Compare with bitwise-and
-# if (presence_vector & HAS_REF_POS_XY_CONF) etc.
+# if (presence_vector & HAS_REF_POS_EL_CONF) etc.
 # Create with bitwise-or
-# presence_vector = presence_vector | HAS_REF_POS_XY_CONF
+# presence_vector = presence_vector | HAS_REF_POS_EL_CONF
 uint8 presence_vector
 
-uint8 HAS_REF_POS_XY_CONF = 1
+uint8 HAS_REF_POS_EL_CONF = 1
 
 j2735_v2x_msgs/ElevationConfidence ref_pos_el_conf


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Previous message definitions of SensorDataSharingMessage.msg in cav_msgs, j3224_msgs, carma_v2x_msgs, and j3224_v2x_msgs had defined the value "HAS_REF_POS_XY_CONF" as an entry in the presence vector to access a valid ElevationConfidence message. This was updated to the value of "HAS_REF_POS_EL_CONF" to reflect the elevation namespace given the SAE J3224 specification.

## Related GitHub Issue

Supports [CARMA Messenger Issue #205](https://github.com/usdot-fhwa-stol/carma-messenger/issues/205)

## Related Jira Key

CDAR-130

## Motivation and Context

Update to comply to SAE J3224 standard for SDSM

## How Has This Been Tested?

carma-msgs builds successfully and the updated values work in the SDSM convertor

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
