### PR TITLE
Add ROS 1 bridge mapping rules

### DIFF
--- a/carma_cooperative_perception_interfaces/CMakeLists.txt
+++ b/carma_cooperative_perception_interfaces/CMakeLists.txt
@@ -59,3 +59,9 @@ if(carma_cooperative_perception_interfaces_BUILD_TESTS)
 endif()
 
 ament_auto_package()
+
+include(GNUInstallDirs)
+
+install(FILES rule.yml
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/carma_cooperative_perception_interfaces
+)

--- a/carma_cooperative_perception_interfaces/package.xml
+++ b/carma_cooperative_perception_interfaces/package.xml
@@ -48,5 +48,6 @@ limitations under the License.
   <export>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <ros1_bridge mapping_rules="rule.yml"/>
   </export>
 </package>

--- a/carma_cooperative_perception_interfaces/rule.yml
+++ b/carma_cooperative_perception_interfaces/rule.yml
@@ -1,0 +1,2 @@
+- ros1_package_name: "carma_cooperative_perception_interfaces"
+  ros2_package_name: "carma_cooperative_perception_interfaces"


### PR DESCRIPTION
# PR Details
## Description

This PR adds ROS 1 bridge topic mapping rules for the `carma_cooperative_perception_interfaces` package. The package name does not adhere to the ROS 1 message naming conventions, so we need to manually specify the mapping.

## Related GitHub Issue

Closes #222 

## Related Jira Key

Closes [CDAR-548](https://usdot-carma.atlassian.net/browse/CDAR-548)

## Motivation and Context

We need this mapping to bridge topics using these message between ROS 1 and ROS 2.

## How Has This Been Tested?

Manually tests

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-548]: https://usdot-carma.atlassian.net/browse/CDAR-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ