### PR TITLE
Add semantic class fields for track and detection

### DIFF
--- a/carma_cooperative_perception_interfaces/msg/Detection.msg
+++ b/carma_cooperative_perception_interfaces/msg/Detection.msg
@@ -13,3 +13,11 @@ uint8 motion_model
 geometry_msgs/PoseWithCovariance pose
 geometry_msgs/TwistWithCovariance twist
 geometry_msgs/AccelWithCovariance accel
+
+uint8 SEMANTIC_CLASS_UNKNOWN=0
+uint8 SEMANTIC_CLASS_SMALL_VEHICLE=1
+uint8 SEMANTIC_CLASS_LARGE_VEHICLE=2
+uint8 SEMANTIC_CLASS_PEDESTRIAN=3
+uint8 SEMANTIC_CLASS_MOTORCYCLE=4
+
+uint8 semantic_class

--- a/carma_cooperative_perception_interfaces/msg/Track.msg
+++ b/carma_cooperative_perception_interfaces/msg/Track.msg
@@ -13,3 +13,11 @@ uint8 motion_model
 geometry_msgs/PoseWithCovariance pose
 geometry_msgs/TwistWithCovariance twist
 geometry_msgs/AccelWithCovariance accel
+
+uint8 SEMANTIC_CLASS_UNKNOWN=0
+uint8 SEMANTIC_CLASS_SMALL_VEHICLE=1
+uint8 SEMANTIC_CLASS_LARGE_VEHICLE=2
+uint8 SEMANTIC_CLASS_PEDESTRIAN=3
+uint8 SEMANTIC_CLASS_MOTORCYCLE=4
+
+uint8 semantic_class


### PR DESCRIPTION
# PR Details
## Description

This PR adds `semantic_class` fields for `Detection.msg` and `Track.msg` messages. The fields are used by upstream and downstream components.

## Related GitHub Issue

Closes #224 

## Related Jira Key

Closes [CDAR-629](https://usdot-carma.atlassian.net/browse/CDAR-629)

## Motivation and Context

See above.

## How Has This Been Tested?

Manually in integration tests.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-629]: https://usdot-carma.atlassian.net/browse/CDAR-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ