### PR TITLE
Add confidence enumerated values to floating points

### DIFF
--- a/j2735_v2x_msgs/.clang-format
+++ b/j2735_v2x_msgs/.clang-format
@@ -1,0 +1,22 @@
+---
+# ROS 2 C++ style guidelines
+# Reference: https://github.com/ament/ament_lint/blob/rolling/ament_clang_format/ament_clang_format/configuration/.clang-format
+
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterEnum: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false

--- a/j2735_v2x_msgs/CMakeLists.txt
+++ b/j2735_v2x_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018-2021 LEIDOS.
+# Copyright (C) 2018-2024 LEIDOS.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 project(j2735_v2x_msgs)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(carma_cmake_common REQUIRED)
 carma_check_ros_version(2)
@@ -25,6 +25,7 @@ carma_package()
 ## Find ament macros and libraries
 find_package(rosidl_default_generators REQUIRED)
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # generate messages
@@ -42,10 +43,29 @@ rosidl_generate_interfaces(
         std_msgs
 )
 
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION include/${PROJECT_NAME}
+)
+
 ament_export_dependencies(rosidl_default_runtime)
+ament_export_include_directories(include)
 ament_package()
 
 install(
   FILES rule.yml
   DESTINATION share/${PROJECT_NAME})
 
+if (BUILD_TESTING)
+  enable_testing()
+
+  include(cmake/ament_auto_find_test_dependencies.cmake)
+  include(cmake/ament_auto_add_gtest.cmake)
+
+  ament_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(j2735_v2x_msgs_tests
+    test/test_to_floating_point.cpp
+  )
+
+  rosidl_target_interfaces(j2735_v2x_msgs_tests ${PROJECT_NAME} "rosidl_typesupport_cpp")
+endif()

--- a/j2735_v2x_msgs/CMakeLists.txt
+++ b/j2735_v2x_msgs/CMakeLists.txt
@@ -58,6 +58,8 @@ install(
 if (BUILD_TESTING)
   enable_testing()
 
+  # These CMake commands were added to ament_cmake_auto in ROS 2 Humble. Until
+  # CARMA supports ROS 2 Humble, we will use package-local copies.
   include(cmake/ament_auto_find_test_dependencies.cmake)
   include(cmake/ament_auto_add_gtest.cmake)
 

--- a/j2735_v2x_msgs/cmake/ament_auto_add_gtest.cmake
+++ b/j2735_v2x_msgs/cmake/ament_auto_add_gtest.cmake
@@ -1,0 +1,112 @@
+# Copyright 2021 Whitley Software Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a gtest with all found test dependencies.
+#
+# Call add_executable(target ARGN), link it against the gtest libraries
+# and all found test dependencies, and then register the executable as a test.
+#
+# If gtest is not available the specified target is not being created and
+# therefore the target existence should be checked before being used.
+#
+# :param target: the target name which will also be used as the test name
+# :type target: string
+# :param ARGN: the list of source files
+# :type ARGN: list of strings
+# :param RUNNER: the path to the test runner script (default:
+#   see ament_add_test).
+# :type RUNNER: string
+# :param TIMEOUT: the test timeout in seconds,
+#   default defined by ``ament_add_test()``
+# :type TIMEOUT: integer
+# :param WORKING_DIRECTORY: the working directory for invoking the
+#   executable in, default defined by ``ament_add_test()``
+# :type WORKING_DIRECTORY: string
+# :param SKIP_LINKING_MAIN_LIBRARIES: if set skip linking against the gtest
+#   main libraries
+# :type SKIP_LINKING_MAIN_LIBRARIES: option
+# :param SKIP_TEST: if set mark the test as being skipped
+# :type SKIP_TEST: option
+# :param ENV: list of env vars to set; listed as ``VAR=value``
+# :type ENV: list of strings
+# :param APPEND_ENV: list of env vars to append if already set, otherwise set;
+#   listed as ``VAR=value``
+# :type APPEND_ENV: list of strings
+# :param APPEND_LIBRARY_DIRS: list of library dirs to append to the appropriate
+#   OS specific env var, a la LD_LIBRARY_PATH
+# :type APPEND_LIBRARY_DIRS: list of strings
+#
+# @public
+#
+macro(ament_auto_add_gtest target)
+  cmake_parse_arguments(_ARG
+    "SKIP_LINKING_MAIN_LIBRARIES;SKIP_TEST"
+    "RUNNER;TIMEOUT;WORKING_DIRECTORY"
+    "APPEND_ENV;APPEND_LIBRARY_DIRS;ENV"
+    ${ARGN})
+  if(NOT _ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "ament_auto_add_gtest() must be invoked with at least one source file")
+  endif()
+
+  # add executable
+  set(_arg_executable ${_ARG_UNPARSED_ARGUMENTS})
+  if(_ARG_SKIP_LINKING_MAIN_LIBRARIES)
+    list(APPEND _arg_executable "SKIP_LINKING_MAIN_LIBRARIES")
+  endif()
+  ament_add_gtest_executable("${target}" ${_arg_executable})
+
+  # add include directory of this package if it exists
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    target_include_directories("${target}" PUBLIC
+      "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  endif()
+
+  # link against other libraries of this package
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+    target_link_libraries("${target}" ${${PROJECT_NAME}_LIBRARIES})
+  endif()
+
+  # add exported information from found dependencies
+  ament_target_dependencies(${target}
+    ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
+    ${${PROJECT_NAME}_FOUND_TEST_DEPENDS}
+  )
+
+  # add test
+  set(_arg_test "")
+  if(_ARG_RUNNER)
+    list(APPEND _arg_test "RUNNER" "${_ARG_RUNNER}")
+  endif()
+  if(_ARG_TIMEOUT)
+    list(APPEND _arg_test "TIMEOUT" "${_ARG_TIMEOUT}")
+  endif()
+  if(_ARG_WORKING_DIRECTORY)
+    list(APPEND _arg_test "WORKING_DIRECTORY" "${_ARG_WORKING_DIRECTORY}")
+  endif()
+  if(_ARG_SKIP_TEST)
+    list(APPEND _arg_test "SKIP_TEST")
+  endif()
+  if(_ARG_ENV)
+    list(APPEND _arg_test "ENV" ${_ARG_ENV})
+  endif()
+  if(_ARG_APPEND_ENV)
+    list(APPEND _arg_test "APPEND_ENV" ${_ARG_APPEND_ENV})
+  endif()
+  if(_ARG_APPEND_LIBRARY_DIRS)
+    list(APPEND _arg_test "APPEND_LIBRARY_DIRS" ${_ARG_APPEND_LIBRARY_DIRS})
+  endif()
+  ament_add_gtest_test("${target}" ${_arg_test})
+endmacro()

--- a/j2735_v2x_msgs/cmake/ament_auto_find_test_dependencies.cmake
+++ b/j2735_v2x_msgs/cmake/ament_auto_find_test_dependencies.cmake
@@ -1,0 +1,41 @@
+# Copyright 2021 Whitley Software Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Invoke find_package() for all test dependencies.
+#
+# All found package names are appended to the
+# ``${PROJECT_NAME}_FOUND_TEST_DEPENDS`` variables.
+#
+# @public
+#
+macro(ament_auto_find_test_dependencies)
+  set(_ARGN "${ARGN}")
+  if(_ARGN)
+    message(FATAL_ERROR "ament_auto_find_test_dependencies() called with "
+      "unused arguments: ${_ARGN}")
+  endif()
+
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+
+  # try to find_package() all test dependencies
+  foreach(_dep ${${PROJECT_NAME}_TEST_DEPENDS})
+    find_package(${_dep} QUIET)
+    if(${_dep}_FOUND)
+      list(APPEND ${PROJECT_NAME}_FOUND_TEST_DEPENDS ${_dep})
+    endif()
+  endforeach()
+endmacro()

--- a/j2735_v2x_msgs/include/j2735_v2x_msgs/to_floating_point.hpp
+++ b/j2735_v2x_msgs/include/j2735_v2x_msgs/to_floating_point.hpp
@@ -1,0 +1,240 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef J2735_V2X_MSGS__TO_FLOATING_POINT_HPP_
+#define J2735_V2X_MSGS__TO_FLOATING_POINT_HPP_
+
+#include <optional>
+
+#include "j2735_v2x_msgs/msg/acceleration_confidence.hpp"
+#include "j2735_v2x_msgs/msg/elevation_confidence.hpp"
+#include "j2735_v2x_msgs/msg/heading_confidence.hpp"
+#include "j2735_v2x_msgs/msg/position_confidence.hpp"
+#include "j2735_v2x_msgs/msg/speed_confidence.hpp"
+#include "j2735_v2x_msgs/msg/yaw_rate_confidence.hpp"
+
+namespace j2735_v2x_msgs
+{
+
+namespace detail
+{
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::AccelerationConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.acceleration_confidence) {
+    case confidence.UNAVAILABLE:
+      return std::nullopt;
+    case confidence.ACCL_100_00:
+      return FloatingPoint{100.0};
+    case confidence.ACCL_010_00:
+      return FloatingPoint{10.0};
+    case confidence.ACCL_005_00:
+      return FloatingPoint{5.0};
+    case confidence.ACCL_001_00:
+      return FloatingPoint{1.0};
+    case confidence.ACCL_000_10:
+      return FloatingPoint{0.1};
+    case confidence.ACCL_000_05:
+      return FloatingPoint{0.05};
+    case confidence.ACCL_000_01:
+      return FloatingPoint{0.01};
+  }
+
+  return std::nullopt;
+}
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::ElevationConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.confidence) {
+    case confidence.UNAVAILABLE:
+      return std::nullopt;
+    case confidence.ELEV_500_00:
+      return FloatingPoint{500.0};
+    case confidence.ELEV_200_00:
+      return FloatingPoint{200.0};
+    case confidence.ELEV_100_00:
+      return FloatingPoint{100.0};
+    case confidence.ELEV_050_00:
+      return FloatingPoint{50.0};
+    case confidence.ELEV_020_00:
+      return FloatingPoint{20.0};
+    case confidence.ELEV_010_00:
+      return FloatingPoint{10.0};
+    case confidence.ELEV_005_00:
+      return FloatingPoint{5.0};
+    case confidence.ELEV_002_00:
+      return FloatingPoint{2.0};
+    case confidence.ELEV_001_00:
+      return FloatingPoint{1.0};
+    case confidence.ELEV_000_50:
+      return FloatingPoint{0.50};
+    case confidence.ELEV_000_20:
+      return FloatingPoint{0.20};
+    case confidence.ELEV_000_10:
+      return FloatingPoint{0.10};
+    case confidence.ELEV_000_05:
+      return FloatingPoint{0.05};
+    case confidence.ELEV_000_02:
+      return FloatingPoint{0.02};
+    case confidence.ELEV_000_01:
+      return FloatingPoint{0.01};
+  }
+
+  return std::nullopt;
+}
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::HeadingConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.confidence) {
+    case confidence.UNAVAILABLE:
+      return std::nullopt;
+    case confidence.PREC_10_DEG:
+      return FloatingPoint{10.0};
+    case confidence.PREC_05_DEG:
+      return FloatingPoint{5.0};
+    case confidence.PREC_01_DEG:
+      return FloatingPoint{1.0};
+    case confidence.PREC_001_DEG:
+      return FloatingPoint{0.1};
+    case confidence.PREC_0005_DEG:
+      return FloatingPoint{0.05};
+    case confidence.PREC_0001_DEG:
+      return FloatingPoint{0.01};
+    case confidence.PREC_000125_DEG:
+      return FloatingPoint{0.0125};
+  }
+
+  return std::nullopt;
+}
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::PositionConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.confidence) {
+    case confidence.UNAVAILABLE:
+      return std::nullopt;
+    case confidence.A500M:
+      return FloatingPoint{500.0};
+    case confidence.A200M:
+      return FloatingPoint{200.0};
+    case confidence.A100M:
+      return FloatingPoint{100.0};
+    case confidence.A50M:
+      return FloatingPoint{50.0};
+    case confidence.A20M:
+      return FloatingPoint{20.0};
+    case confidence.A10M:
+      return FloatingPoint{10.0};
+    case confidence.A5M:
+      return FloatingPoint{5.0};
+    case confidence.A2M:
+      return FloatingPoint{2.0};
+    case confidence.A1M:
+      return FloatingPoint{1.0};
+    case confidence.A50CM:
+      return FloatingPoint{0.50};
+    case confidence.A20CM:
+      return FloatingPoint{0.20};
+    case confidence.A10CM:
+      return FloatingPoint{0.10};
+    case confidence.A5CM:
+      return FloatingPoint{0.05};
+    case confidence.A2CM:
+      return FloatingPoint{0.02};
+    case confidence.A1CM:
+      return FloatingPoint{0.01};
+  }
+
+  return std::nullopt;
+}
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::SpeedConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.speed_confidence) {
+    case confidence.UNAVAILABLE:
+      return std::nullopt;
+    case confidence.PREC100MS:
+      return FloatingPoint{100.0};
+    case confidence.PREC10MS:
+      return FloatingPoint{10.0};
+    case confidence.PREC5MS:
+      return FloatingPoint{5.0};
+    case confidence.PREC1MS:
+      return FloatingPoint{1.0};
+    case confidence.PREC0_1MS:
+      return FloatingPoint{0.1};
+    case confidence.PREC0_05MS:
+      return FloatingPoint{0.05};
+    case confidence.PREC0_01MS:
+      return FloatingPoint{0.01};
+  }
+
+  return std::nullopt;
+}
+
+template <typename FloatingPoint>
+auto to_floating_point(const j2735_v2x_msgs::msg::YawRateConfidence & confidence)
+  -> std::optional<FloatingPoint>
+{
+  switch (confidence.yaw_rate_confidence) {
+    // The YawRateConfidence message does not define an UNAVAILABLE labeled
+    // enumeration value. See https://usdot-carma.atlassian.net/browse/CDAR-733
+    // for status updates.
+    case 0:
+      return std::nullopt;
+    case confidence.DEG_SEC_100_00:
+      return FloatingPoint{100.0};
+    case confidence.DEG_SEC_010_00:
+      return FloatingPoint{10.0};
+    case confidence.DEG_SEC_005_00:
+      return FloatingPoint{5.0};
+    case confidence.DEG_SEC_001_00:
+      return FloatingPoint{1.0};
+    case confidence.DEG_SEC_000_10:
+      return FloatingPoint{0.1};
+    case confidence.DEG_SEC_000_05:
+      return FloatingPoint{0.05};
+    case confidence.DEG_SEC_000_01:
+      return FloatingPoint{0.01};
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace detail
+
+template <typename Confidence>
+auto to_float(const Confidence & confidence)
+{
+  return detail::to_floating_point<float>(confidence);
+}
+
+template <typename Confidence>
+auto to_double(const Confidence & confidence)
+{
+  return detail::to_floating_point<double>(confidence);
+}
+
+}  // namespace j2735_v2x_msgs
+
+#endif  // J2735_V2X_MSGS__TO_FLOATING_POINT_HPP_

--- a/j2735_v2x_msgs/package.xml
+++ b/j2735_v2x_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (C) 2018-2021 LEIDOS.
+  Copyright (C) 2018-2024 LEIDOS.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -25,11 +25,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  
+
+  <build_depend>ament_cmake_auto</build_depend>
   <build_depend>carma_cmake_common</build_depend>
   <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/j2735_v2x_msgs/test/test_to_floating_point.cpp
+++ b/j2735_v2x_msgs/test/test_to_floating_point.cpp
@@ -1,0 +1,324 @@
+// Copyright 2024 Leidos
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <j2735_v2x_msgs/msg/acceleration_confidence.hpp>
+#include <j2735_v2x_msgs/msg/elevation_confidence.hpp>
+#include <j2735_v2x_msgs/msg/heading_confidence.hpp>
+#include <j2735_v2x_msgs/msg/position_confidence.hpp>
+#include <j2735_v2x_msgs/msg/speed_confidence.hpp>
+#include <j2735_v2x_msgs/msg/yaw_rate_confidence.hpp>
+#include <j2735_v2x_msgs/to_floating_point.hpp>
+
+TEST(ToFloatingPoint, AccelerationConfidence)
+{
+  using j2735_v2x_msgs::msg::AccelerationConfidence;
+
+  AccelerationConfidence confidence;
+
+  confidence.acceleration_confidence = AccelerationConfidence::UNAVAILABLE;
+  EXPECT_EQ(j2735_v2x_msgs::to_float(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_100_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 100.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 100.0);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_010_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_005_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_001_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_000_10;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_000_05;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.acceleration_confidence = AccelerationConfidence::ACCL_000_01;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+}
+
+TEST(ToFloatingPoint, ElevationConfidence)
+{
+  using j2735_v2x_msgs::msg::ElevationConfidence;
+
+  ElevationConfidence confidence;
+
+  confidence.confidence = ElevationConfidence::UNAVAILABLE;
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.confidence = ElevationConfidence::ELEV_500_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 500.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 500.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_200_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 200.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 200.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_100_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 100.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 100.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_050_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 50.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 50.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_020_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 20.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 20.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_010_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_005_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_002_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 2.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 2.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_001_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_50;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.5F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.5);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_20;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.2F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.2);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_10;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_05;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_02;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.02F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.02);
+
+  confidence.confidence = ElevationConfidence::ELEV_000_01;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+}
+
+TEST(ToFloatingPoint, HeadingConfidence)
+{
+  using j2735_v2x_msgs::msg::HeadingConfidence;
+
+  HeadingConfidence confidence;
+
+  confidence.confidence = HeadingConfidence::UNAVAILABLE;
+  EXPECT_EQ(j2735_v2x_msgs::to_float(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.confidence = HeadingConfidence::PREC_10_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.confidence = HeadingConfidence::PREC_05_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.confidence = HeadingConfidence::PREC_01_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.confidence = HeadingConfidence::PREC_001_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.confidence = HeadingConfidence::PREC_0005_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.confidence = HeadingConfidence::PREC_0001_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+
+  confidence.confidence = HeadingConfidence::PREC_000125_DEG;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.0125F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.0125);
+}
+
+TEST(ToFloatingPoint, PositionConfidence)
+{
+  using j2735_v2x_msgs::msg::PositionConfidence;
+
+  PositionConfidence confidence;
+
+  confidence.confidence = PositionConfidence::UNAVAILABLE;
+  EXPECT_EQ(j2735_v2x_msgs::to_float(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.confidence = PositionConfidence::A500M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 500.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 500.0);
+
+  confidence.confidence = PositionConfidence::A200M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 200.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 200.0);
+
+  confidence.confidence = PositionConfidence::A100M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 100.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 100.0);
+
+  confidence.confidence = PositionConfidence::A50M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 50.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 50.0);
+
+  confidence.confidence = PositionConfidence::A20M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 20.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 20.0);
+
+  confidence.confidence = PositionConfidence::A10M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.confidence = PositionConfidence::A5M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.confidence = PositionConfidence::A2M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 2.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 2.0);
+
+  confidence.confidence = PositionConfidence::A1M;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.confidence = PositionConfidence::A50CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.5F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.5);
+
+  confidence.confidence = PositionConfidence::A20CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.2F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.2);
+
+  confidence.confidence = PositionConfidence::A10CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.confidence = PositionConfidence::A5CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.confidence = PositionConfidence::A2CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.02F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.02);
+
+  confidence.confidence = PositionConfidence::A1CM;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+}
+
+TEST(ToFloatingPoint, SpeedConfidence)
+{
+  using j2735_v2x_msgs::msg::SpeedConfidence;
+
+  SpeedConfidence confidence;
+
+  confidence.speed_confidence = SpeedConfidence::UNAVAILABLE;
+  EXPECT_EQ(j2735_v2x_msgs::to_float(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.speed_confidence = SpeedConfidence::PREC100MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 100.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 100.0);
+
+  confidence.speed_confidence = SpeedConfidence::PREC10MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.speed_confidence = SpeedConfidence::PREC5MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.speed_confidence = SpeedConfidence::PREC1MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.speed_confidence = SpeedConfidence::PREC0_1MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.speed_confidence = SpeedConfidence::PREC0_05MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.speed_confidence = SpeedConfidence::PREC0_01MS;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+}
+
+TEST(ToFloatingPoint, YawRateConfidence)
+{
+  using j2735_v2x_msgs::msg::YawRateConfidence;
+
+  YawRateConfidence confidence;
+
+  // The YawRateConfidence message does not define an UNAVAILABLE labeled
+  // enumeration value. See https://usdot-carma.atlassian.net/browse/CDAR-733
+  // for status updates.
+  confidence.yaw_rate_confidence = 0;
+  EXPECT_EQ(j2735_v2x_msgs::to_float(confidence), std::nullopt);
+  EXPECT_EQ(j2735_v2x_msgs::to_double(confidence), std::nullopt);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_100_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 100.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 100.0);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_010_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 10.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 10.0);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_005_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 5.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 5.0);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_001_00;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 1.0F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 1.0);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_000_10;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.1F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.1);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_000_05;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.05F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.05);
+
+  confidence.yaw_rate_confidence = YawRateConfidence::DEG_SEC_000_01;
+  EXPECT_FLOAT_EQ(j2735_v2x_msgs::to_float(confidence).value(), 0.01F);
+  EXPECT_DOUBLE_EQ(j2735_v2x_msgs::to_double(confidence).value(), 0.01);
+}


### PR DESCRIPTION
# PR Details
## Description

This PR adds some convenience functions to convert the SAE confidence enumerated values to floating point equivalents. The enumerated values aren't really useful beyond standardizing data representation in messages.

## Related GitHub Issue

## Related Jira Key

Closes [CDAR-734](https://usdot-carma.atlassian.net/browse/CDAR-734)

## Motivation and Context

Need the confidence values to generate covariance matrices. Floating point representations help with this.

## How Has This Been Tested?

Unit tests.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CDAR-734]: https://usdot-carma.atlassian.net/browse/CDAR-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ