### PR TITLE
ARC 258 Fix Include Install

### DIFF
--- a/j2735_v2x_msgs/CMakeLists.txt
+++ b/j2735_v2x_msgs/CMakeLists.txt
@@ -85,10 +85,9 @@ else() # ROS 2
     DESTINATION include/${PROJECT_NAME}
   )
 
-  set(INCLUDE_DESTINATION include/${PROJECT_NAME})
+  set(INCLUDE_DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
 
   ament_export_dependencies(rosidl_default_runtime)
-  ament_export_include_directories(include)
   ament_package()
 
   if (BUILD_TESTING)
@@ -107,6 +106,6 @@ endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING PATTERN "*.hpp"
   PATTERN ".svn" EXCLUDE
 )

--- a/j3224_v2x_msgs/CMakeLists.txt
+++ b/j3224_v2x_msgs/CMakeLists.txt
@@ -88,7 +88,7 @@ else() # ROS 2
           j2735_v2x_msgs
   )
 
-  set(INCLUDE_DESTINATION include/${PROJECT_NAME})
+  set(INCLUDE_DESTINATION include/${PROJECT_NAME}/${PROJECT_NAME})
 
   ament_export_dependencies(rosidl_default_runtime)
   ament_package()
@@ -97,6 +97,6 @@ endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${INCLUDE_DESTINATION}
-  FILES_MATCHING PATTERN "*.h"
+  FILES_MATCHING PATTERN "*.hpp"
   PATTERN ".svn" EXCLUDE
 )


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes the installation of the include directory for the j2735 and j3224 v2x message packages.

## Related GitHub Issue

NA
## Related Jira Key

[ARC-258](https://usdot-carma.atlassian.net/browse/ARC-258)

## Motivation and Context

This PR is needed for packages that include the file `j2735_v2x_msgs/to_floating_point.hpp` to build.

## How Has This Been Tested?

Confirmed that packages that need the file  `j2735_v2x_msgs/to_floating_point.hpp` can build.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[ARC-258]: https://usdot-carma.atlassian.net/browse/ARC-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ